### PR TITLE
Store logs in Sqlite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2390,6 +2390,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2790,6 +2802,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
 dependencies = [
  "fxhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692eaaf7f7607518dd3cef090f1474b61edc5301d8012f09579920df68b725ee"
+dependencies = [
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -4094,6 +4115,16 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -5745,6 +5776,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.5.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6462,36 +6507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlite"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf42adadeba1af33e2778aa22a6e9c487d8a0e3170fe65e6cb8775b3c59eb99"
-dependencies = [
- "libc",
- "sqlite3-sys",
-]
-
-[[package]]
-name = "sqlite3-src"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9448d45899495acd1a46b0b888ae9747c13551fb0d8f4a60ab485da52b040503"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
-name = "sqlite3-sys"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed0b61828382e1103930d2d5df1972d493173319730b481192e63d929097321"
-dependencies = [
- "libc",
- "sqlite3-src",
-]
-
-[[package]]
 name = "sqlparser"
 version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6910,6 +6925,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rusqlite"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2cc5f712424f089fc6549afe39773e9f8914ce170c45b546be24830b482b127"
+dependencies = [
+ "crossbeam-channel",
+ "rusqlite",
  "tokio",
 ]
 
@@ -7906,11 +7932,11 @@ dependencies = [
  "serde-rename-rule",
  "serde_json",
  "sha3",
- "sqlite",
  "subsquid-messages",
  "subsquid-network-transport",
  "thiserror",
  "tokio",
+ "tokio-rusqlite",
  "tokio-stream",
  "tokio-util",
  "tower-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,11 +36,11 @@ serde = "1.0.195"
 serde-rename-rule = "0.2.2"
 serde_json = { version = "1.0.111", features = ["preserve_order"] }
 sha3 = "0.10.8"
-sqlite = "0.34.0"
 subsquid-messages = { git = "ssh://git@github.com/subsquid/archive-router.git", rev = "5185696", features = ["signatures"] }
 subsquid-network-transport = { git = "ssh://git@github.com/subsquid/subsquid-network.git", rev = "c083749", features = ["metrics"] }
 thiserror = "1.0.57"
 tokio = { version = "1.35.1", features = ["full", "tracing"] }
+tokio-rusqlite = "0.5.1"
 tokio-stream = "0.1.14"
 tokio-util = "0.7.10"
 tower-http = { version = "0.5.1", features = ["catch-panic"] }

--- a/src/logs_storage/mod.rs
+++ b/src/logs_storage/mod.rs
@@ -1,31 +1,110 @@
-use subsquid_messages::QueryExecuted;
+use std::sync::atomic::{AtomicBool, Ordering};
 
-#[derive(Default)]
+use anyhow::Result;
+use prost::Message;
+use subsquid_messages::QueryExecuted;
+use tokio_rusqlite::Connection;
+
 pub struct LogsStorage {
-    logs: Vec<(usize, QueryExecuted)>,
-    next_seq_no: Option<usize>,
+    db: Connection,
+    has_next_seq_no: AtomicBool,
 }
 
 impl LogsStorage {
+    pub async fn new(logs_path: &str) -> Result<Self> {
+        let db = Connection::open(logs_path).await?;
+        let has_next_seq_no = db
+            .call(|db| {
+                db.execute_batch(
+                    r#"
+                    BEGIN;
+                    CREATE TABLE IF NOT EXISTS query_logs(seq_no INTEGER PRIMARY KEY, log_msg BLOB);
+                    CREATE TABLE IF NOT EXISTS next_seq_no(seq_no);
+                    COMMIT;"#,
+                )?;
+                let has_next_seq_no = db.prepare("SELECT seq_no FROM next_seq_no")?.exists(())?;
+                Ok(has_next_seq_no)
+            })
+            .await?;
+
+        Ok(Self {
+            db,
+            has_next_seq_no: AtomicBool::new(has_next_seq_no),
+        })
+    }
+
     pub fn is_initialized(&self) -> bool {
-        self.next_seq_no.is_some()
+        self.has_next_seq_no.load(Ordering::SeqCst)
     }
 
-    pub fn save_log(&mut self, mut log: QueryExecuted) {
-        let next_seq_no = self.next_seq_no.expect("Logs storage is not initialized");
-        self.next_seq_no = Some(next_seq_no + 1);
-        log.seq_no = Some(next_seq_no as u64);
-        log.timestamp_ms = Some(timestamp_now_ms());
+    pub async fn save_log(&self, mut log: QueryExecuted) -> Result<()> {
+        assert!(self.is_initialized());
+        self.db
+            .call(move |db| {
+                let tx = db.transaction()?;
+                log.timestamp_ms = Some(timestamp_now_ms());
+                tx.prepare_cached("INSERT INTO query_logs SELECT seq_no, ? FROM next_seq_no")
+                    .expect("Couldn't prepare logs insertion query")
+                    .execute([log.encode_to_vec()])?;
+                tx.prepare_cached("UPDATE next_seq_no SET seq_no = seq_no + 1")
+                    .expect("Couldn't prepare next_seq_no update query")
+                    .execute(())?;
+                tx.commit()?;
+                Ok(())
+            })
+            .await?;
+        Ok(())
     }
 
-    pub fn logs_collected(&mut self, last_collected_seq_no: Option<usize>) {
+    /// All logs with sequence numbers up to `last_collected_seq_no` have been saved by the logs collector
+    /// and should be discarded from the storage.
+    pub async fn logs_collected(&self, last_collected_seq_no: Option<usize>) {
+        tracing::debug!(
+            "Logs up to {} collected",
+            last_collected_seq_no.unwrap_or(0)
+        );
         let next_seq_no = last_collected_seq_no.map(|x| x + 1).unwrap_or(0);
-        self.logs.retain(|(seq_no, _log)| seq_no >= &next_seq_no);
-        self.next_seq_no = Some(next_seq_no);
+        if self.is_initialized() {
+            self.db
+                .call_unwrap(move |db| {
+                    tracing::debug!("Deleting collected logs up to {}", next_seq_no);
+                    db.prepare_cached("DELETE FROM query_logs WHERE seq_no < ?")
+                        .expect("Couldn't prepare logs deletion query")
+                        .execute([next_seq_no])
+                })
+                .await
+                .expect("Couldn't delete logs from DB");
+        } else {
+            self.db
+                .call_unwrap(move |db| {
+                    db.execute("INSERT INTO next_seq_no VALUES(?)", [next_seq_no])
+                })
+                .await
+                .expect("Couldn't initialize logs storage");
+            if self.has_next_seq_no.swap(true, Ordering::SeqCst) {
+                panic!("Tried to initialize logs storage twice");
+            }
+            tracing::info!("Initialized logs storage");
+        }
     }
 
-    pub fn take_logs(&mut self) -> Vec<QueryExecuted> {
-        self.logs.drain(..).map(|(_seq_no, log)| log).collect()
+    pub async fn get_logs(&self) -> Result<Vec<QueryExecuted>> {
+        self.db
+            .call_unwrap(|db| {
+                let mut stmt = db
+                    .prepare_cached("SELECT seq_no, log_msg FROM query_logs")
+                    .expect("Couldn't prepare logs query");
+                let logs = stmt.query([])?.and_then(|row| {
+                    let seq_no: u64 = row.get(0)?;
+                    let log_msg: Vec<u8> = row.get(1)?;
+                    let mut log: QueryExecuted =
+                        QueryExecuted::decode(&log_msg[..]).expect("Invalid log proto in DB");
+                    log.seq_no = Some(seq_no);
+                    Ok(log)
+                });
+                logs.collect::<Result<Vec<_>>>()
+            })
+            .await
     }
 }
 
@@ -35,4 +114,80 @@ fn timestamp_now_ms() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .expect("Invalid current time")
         .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use subsquid_messages::query_executed::Result;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_logs_storage() {
+        let logs_storage = LogsStorage::new(":memory:").await.unwrap();
+        assert!(!logs_storage.is_initialized());
+        logs_storage.logs_collected(Some(2)).await;
+        assert!(logs_storage.is_initialized());
+        logs_storage
+            .save_log(QueryExecuted {
+                query: Some(subsquid_messages::Query {
+                    query_id: Some("0".to_owned()),
+                    dataset: Some("eth-main".to_owned()),
+                    query: Some("{}".to_owned()),
+                    ..Default::default()
+                }),
+                result: Some(Result::Ok(Default::default())),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        logs_storage
+            .save_log(QueryExecuted {
+                query: Some(subsquid_messages::Query {
+                    query_id: Some("1".to_owned()),
+                    dataset: Some("eth-main".to_owned()),
+                    query: Some("{}".to_owned()),
+                    ..Default::default()
+                }),
+                result: Some(Result::BadRequest("Invalid query".to_owned())),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let logs = logs_storage.get_logs().await.unwrap();
+        assert_eq!(logs.len(), 2);
+        assert_eq!(logs[0].seq_no, Some(3));
+        assert_eq!(
+            logs[0].query.as_ref().unwrap().query_id.as_deref(),
+            Some("0")
+        );
+        assert_eq!(logs[0].result, Some(Result::Ok(Default::default())));
+        assert_eq!(logs[1].seq_no, Some(4));
+        assert_eq!(
+            logs[1].query.as_ref().unwrap().query_id.as_deref(),
+            Some("1")
+        );
+        assert_eq!(
+            logs[1].result,
+            Some(Result::BadRequest("Invalid query".to_owned()))
+        );
+
+        logs_storage.logs_collected(Some(3)).await;
+        let logs = logs_storage.get_logs().await.unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].seq_no, Some(4));
+        assert_eq!(
+            logs[0].query.as_ref().unwrap().query_id.as_deref(),
+            Some("1")
+        );
+        assert_eq!(
+            logs[0].result,
+            Some(Result::BadRequest("Invalid query".to_owned()))
+        );
+
+        logs_storage.logs_collected(Some(100)).await;
+        let logs = logs_storage.get_logs().await.unwrap();
+        assert!(logs.is_empty());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,13 @@ async fn main() -> anyhow::Result<()> {
             ..
         }) => {
             let transport = Arc::new(
-                create_p2p_transport(transport_args, scheduler_id, logs_collector_id).await?,
+                create_p2p_transport(
+                    transport_args,
+                    scheduler_id,
+                    logs_collector_id,
+                    args.data_dir.join("logs.db"),
+                )
+                .await?,
             );
             let allocations_checker: Arc<dyn AllocationsChecker> = if let Some(rpc) = rpc {
                 Arc::new(


### PR DESCRIPTION
Persist logs on disk for the case the worker shuts down before they were collected.
Mostly copied from here: https://github.com/subsquid/archive.py/blob/master/sqa/worker/p2p/query_logs.py