### PR TITLE
Prepare worker for use with the new gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,7 +1191,7 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 [[package]]
 name = "contract-client"
 version = "1.0.4"
-source = "git+https://github.com/subsquid/subsquid-network.git#d4a381cf7c0d3c93c96da5523d2f746726158095"
+source = "git+https://github.com/subsquid/subsquid-network.git#a5be5019d9e1525c782810417e056f25a0ba6c62"
 dependencies = [
  "async-trait",
  "clap",
@@ -5069,7 +5069,7 @@ checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -5089,7 +5089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9554e3ab233f0a932403704f1a1d08c30d5ccd931adfdfa1e8b5a19b52c1d55a"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.66",
@@ -6279,8 +6279,8 @@ dependencies = [
 
 [[package]]
 name = "subsquid-messages"
-version = "1.0.2"
-source = "git+https://github.com/subsquid/subsquid-network.git#d4a381cf7c0d3c93c96da5523d2f746726158095"
+version = "1.1.0"
+source = "git+https://github.com/subsquid/subsquid-network.git#a5be5019d9e1525c782810417e056f25a0ba6c62"
 dependencies = [
  "anyhow",
  "hex",
@@ -6295,7 +6295,7 @@ dependencies = [
 [[package]]
 name = "subsquid-network-transport"
 version = "1.0.11"
-source = "git+https://github.com/subsquid/subsquid-network.git#d4a381cf7c0d3c93c96da5523d2f746726158095"
+source = "git+https://github.com/subsquid/subsquid-network.git#a5be5019d9e1525c782810417e056f25a0ba6c62"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,7 +1191,7 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 [[package]]
 name = "contract-client"
 version = "1.0.4"
-source = "git+https://github.com/subsquid/subsquid-network.git#594ca8705a6819a1b317043ff0b6cbe5ed580916"
+source = "git+https://github.com/subsquid/subsquid-network.git#7906af9805553b868a8d617a9bcdac83af5c98df"
 dependencies = [
  "async-trait",
  "clap",
@@ -5069,7 +5069,7 @@ checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -5089,7 +5089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9554e3ab233f0a932403704f1a1d08c30d5ccd931adfdfa1e8b5a19b52c1d55a"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.66",
@@ -6280,7 +6280,7 @@ dependencies = [
 [[package]]
 name = "subsquid-messages"
 version = "1.1.0"
-source = "git+https://github.com/subsquid/subsquid-network.git#594ca8705a6819a1b317043ff0b6cbe5ed580916"
+source = "git+https://github.com/subsquid/subsquid-network.git#7906af9805553b868a8d617a9bcdac83af5c98df"
 dependencies = [
  "anyhow",
  "hex",
@@ -6294,8 +6294,8 @@ dependencies = [
 
 [[package]]
 name = "subsquid-network-transport"
-version = "1.0.11"
-source = "git+https://github.com/subsquid/subsquid-network.git#594ca8705a6819a1b317043ff0b6cbe5ed580916"
+version = "1.0.12"
+source = "git+https://github.com/subsquid/subsquid-network.git#7906af9805553b868a8d617a9bcdac83af5c98df"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6535,9 +6535,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
 dependencies = [
  "cc",
  "libc",
@@ -6545,9 +6545,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,7 +1191,7 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 [[package]]
 name = "contract-client"
 version = "1.0.4"
-source = "git+https://github.com/subsquid/subsquid-network.git#a5be5019d9e1525c782810417e056f25a0ba6c62"
+source = "git+https://github.com/subsquid/subsquid-network.git#594ca8705a6819a1b317043ff0b6cbe5ed580916"
 dependencies = [
  "async-trait",
  "clap",
@@ -6280,7 +6280,7 @@ dependencies = [
 [[package]]
 name = "subsquid-messages"
 version = "1.1.0"
-source = "git+https://github.com/subsquid/subsquid-network.git#a5be5019d9e1525c782810417e056f25a0ba6c62"
+source = "git+https://github.com/subsquid/subsquid-network.git#594ca8705a6819a1b317043ff0b6cbe5ed580916"
 dependencies = [
  "anyhow",
  "hex",
@@ -6295,7 +6295,7 @@ dependencies = [
 [[package]]
 name = "subsquid-network-transport"
 version = "1.0.11"
-source = "git+https://github.com/subsquid/subsquid-network.git#a5be5019d9e1525c782810417e056f25a0ba6c62"
+source = "git+https://github.com/subsquid/subsquid-network.git#594ca8705a6819a1b317043ff0b6cbe5ed580916"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6325,7 +6325,7 @@ dependencies = [
 
 [[package]]
 name = "subsquid-worker"
-version = "1.0.4-rc1"
+version = "1.1.0-rc1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6325,7 +6325,7 @@ dependencies = [
 
 [[package]]
 name = "subsquid-worker"
-version = "1.1.0-rc1"
+version = "1.1.0-rc2"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "subsquid-worker"
 license = "AGPL-3.0-or-later"
-version = "1.1.0-rc1"
+version = "1.1.0-rc2"
 edition = "2021"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 walkdir = "2.5.0"
 
 contract-client = { git = "https://github.com/subsquid/subsquid-network.git", version = "1.0.4" }
-subsquid-messages = { git = "https://github.com/subsquid/subsquid-network.git", version = "1.0.2" }
+subsquid-messages = { git = "https://github.com/subsquid/subsquid-network.git", version = "1.1.0" }
 subsquid-network-transport = { git = "https://github.com/subsquid/subsquid-network.git", version = "1.0.11", features = ["worker", "metrics"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,10 +50,10 @@ walkdir = "2.5.0"
 
 contract-client = { git = "https://github.com/subsquid/subsquid-network.git", version = "1.0.4" }
 subsquid-messages = { git = "https://github.com/subsquid/subsquid-network.git", version = "1.1.0" }
-subsquid-network-transport = { git = "https://github.com/subsquid/subsquid-network.git", version = "1.0.11", features = ["worker", "metrics"] }
+subsquid-network-transport = { git = "https://github.com/subsquid/subsquid-network.git", version = "1.0.12", features = ["worker", "metrics"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = "0.5"
+tikv-jemallocator = "0.6"
 
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "subsquid-worker"
 license = "AGPL-3.0-or-later"
-version = "1.0.4-rc1"
+version = "1.1.0-rc1"
 edition = "2021"
 
 [[bin]]

--- a/src/controller/p2p.rs
+++ b/src/controller/p2p.rs
@@ -60,7 +60,7 @@ pub async fn create_p2p_controller(
     logs_collector_id: PeerId,
     data_dir: PathBuf,
     ping_interval: Duration,
-) -> Result<P2PController<impl Stream<Item=WorkerEvent>>> {
+) -> Result<P2PController<impl Stream<Item = WorkerEvent>>> {
     let worker_id = transport_builder.local_peer_id();
     info!("Local peer ID: {worker_id}");
     check_peer_id(worker_id, data_dir.join("peer_id"));
@@ -85,7 +85,7 @@ pub async fn create_p2p_controller(
     })
 }
 
-impl<EventStream: Stream<Item=WorkerEvent>> P2PController<EventStream> {
+impl<EventStream: Stream<Item = WorkerEvent>> P2PController<EventStream> {
     pub async fn run(&self, cancellation_token: CancellationToken) {
         run_all!(
             cancellation_token,
@@ -298,6 +298,7 @@ impl<EventStream: Stream<Item=WorkerEvent>> P2PController<EventStream> {
             Ok(result) => query_result::Result::Ok(subsquid_messages::OkResult {
                 data: result.compressed_data,
                 exec_plan: None,
+                last_block: result.last_block,
             }),
             Err(e @ QueryError::NotFound) => query_result::Result::BadRequest(e.to_string()),
             Err(QueryError::NoAllocation) => query_result::Result::NoAllocation(()),

--- a/src/controller/p2p.rs
+++ b/src/controller/p2p.rs
@@ -278,10 +278,15 @@ impl<EventStream: Stream<Item = WorkerEvent>> P2PController<EventStream> {
                 "Some fields are missing in proto message".to_owned(),
             ))?;
         };
-        if let Some(future) =
-            self.worker
-                .schedule_query(query_str.clone(), dataset.clone(), Some(peer_id))
-        {
+        let block_range = query
+            .block_range
+            .map(|subsquid_messages::Range { begin, end }| (begin as u64, end as u64));
+        if let Some(future) = self.worker.schedule_query(
+            query_str.clone(),
+            dataset.clone(),
+            block_range,
+            Some(peer_id),
+        ) {
             future.await
         } else {
             Err(QueryError::ServiceOverloaded)

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -52,7 +52,7 @@ async fn run_query(
     Path(dataset): Path<Dataset>,
     query_str: String,
 ) -> Response {
-    if let Some(future) = worker.schedule_query(query_str, dataset, None) {
+    if let Some(future) = worker.schedule_query(query_str, dataset, None, None) {
         future.await.map(|result| result.raw_data).into_response()
     } else {
         Response::builder()

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -64,9 +64,7 @@ pub fn query_executed(result: &Result<QueryResult, QueryError>) {
     let (status, result) = match result {
         Ok(result) => (QueryStatus::Ok, Some(result)),
         Err(QueryError::NoAllocation) => (QueryStatus::NoAllocation, None),
-        Err(QueryError::NotFound | QueryError::BadRequest(_)) => {
-            (QueryStatus::BadRequest, None)
-        }
+        Err(QueryError::NotFound | QueryError::BadRequest(_)) => (QueryStatus::BadRequest, None),
         Err(QueryError::Other(_) | QueryError::ServiceOverloaded) => {
             (QueryStatus::ServerError, None)
         }


### PR DESCRIPTION
This PR changes the output format of the query results, i.e., of the [`data`](https://github.com/subsquid/subsquid-network/blob/main/messages/proto/messages.proto#L103) field.
- The result is written in the [JSON lines](https://jsonlines.org/) format instead of a single JSON array. Rationale can be found [here](https://github.com/subsquid/sqn-query/pull/1).
- The result is limited in size to fit in the allowed transport message limit.
- The last included block is returned to simplify forming a follow-up request.
- The block range is passed separately from the query body.