### PR TITLE
Fix lock ordering deadlock in StateManager

### DIFF
--- a/src/storage/manager.rs
+++ b/src/storage/manager.rs
@@ -28,9 +28,9 @@ use super::{
 
 pub struct StateManager {
     fs: LocalFs,
+    datasets_index: Mutex<Option<DatasetsIndex>>,
     state: Mutex<State>,
     notify: tokio::sync::Notify,
-    datasets_index: Mutex<Option<DatasetsIndex>>,
     concurrent_downloads: usize,
     worker_id: PeerId,
     args: Args,

--- a/src/storage/manager.rs
+++ b/src/storage/manager.rs
@@ -164,8 +164,8 @@ impl StateManager {
     // TODO: prevent accidental massive removals
     #[instrument(skip_all)]
     fn set_desired_chunks(&self, desired_chunks: ChunkSet, datasets_index: DatasetsIndex) {
-        let mut state = self.state.lock();
         let mut index = self.datasets_index.lock();
+        let mut state = self.state.lock();
         match state.set_desired_chunks(desired_chunks) {
             UpdateStatus::Unchanged => {}
             UpdateStatus::Updated => {


### PR DESCRIPTION
set_desired_chunks acquired state before datasets_index, while run() acquires them in the opposite order — a classic AB-BA pattern that could deadlock when a new assignment arrives concurrently with the download loop. Align the order with run() (datasets_index then state).

Introduced in #38 when set_desired_chunks and set_datasets_index were merged into one function without aligning lock acquisition order.