### PR TITLE
docs: factual README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,79 @@
-## SQD worker
+# SQD Network Worker (Rust)
 
-This is a Rust implementation of the Worker. The previous (Python) version can be found [here](https://github.com/subsquid/archive.py/tree/master).
+A worker node for [SQD Network](https://sqd.dev/network), written in Rust. A worker downloads its assigned slice of the network's data lake from persistent storage (currently S3) and answers data queries that reference those chunks.
 
-A worker is a service that downloads assigned data chunks from persistent storage (currently S3) and processes incoming data queries that reference those data chunks.
+This is the Rust implementation of the worker. The previous Python version lives in [subsquid/archive.py](https://github.com/subsquid/archive.py/tree/master).
 
-For details see [network RFC](https://github.com/subsquid/specs/tree/main/network-rfc) page.
+## What it is
+
+SQD Network is a decentralized data lake. The dataset is split into chunks that are distributed across many worker nodes. Each worker:
+
+- Receives a chunk assignment, then downloads the assigned chunks from persistent storage (S3) into a local data directory.
+- Joins the network over a libp2p peer-to-peer transport (QUIC) using a peer ID, and serves queries routed to the chunks it holds.
+- Executes queries against its local data using a query engine built on [Polars](https://pola.rs) and the [SQD query crate](https://github.com/subsquid/data).
+- Exposes an HTTP endpoint with status and Prometheus metrics.
+
+The crate is published as `sqd-worker`. It depends on shared network crates from [subsquid/sqd-network](https://github.com/subsquid/sqd-network) (transport, messages, contract client, assignments) and query crates from [subsquid/data](https://github.com/subsquid/data).
+
+For protocol details, see the [network RFC](https://github.com/subsquid/specs/tree/main/network-rfc).
+
+## Running a worker
+
+If you want to operate a worker on SQD Network, follow the worker setup guide in the docs:
+
+https://docs.sqd.dev/subsquid-network/participate/worker/
+
+## Build
+
+Requires the Rust toolchain pinned in `rust-toolchain.toml` (Rust 1.89). Native build dependencies: `protobuf-compiler`, `pkg-config`, `libssl-dev`, and `libsqlite3-dev`.
+
+```bash
+cargo build --release
+```
+
+The binary is produced at `target/release/sqd-worker`.
+
+### Docker
+
+A `Dockerfile` is provided. It builds the worker with `cargo-chef` for layer caching and produces an image whose entrypoint is the worker binary:
+
+```bash
+docker build -t sqd-worker .
+```
 
 ## Usage
 
-You can find instructions for how to run your own worker [here](https://docs.sqd.dev/subsquid-network/participate/worker/).
+The worker is configured through command-line flags or the equivalent environment variables (most flags also read from `env`). Key options:
+
+| Flag | Env | Default | Description |
+|---|---|---|---|
+| `--data-dir` | `DATA_DIR` | (required) | Directory for the worker's data and state |
+| `--prometheus-port` | `PROMETHEUS_PORT` | `8000` | Port for the HTTP status and metrics server |
+| `--p2p-port` | `LISTEN_PORT` | `12345` | P2P (QUIC) port to listen on |
+| `--public-ip` | `PUBLIC_IP` | (none) | Public IP address to advertise to peers |
+| `--parallel-queries` | `PARALLEL_QUERIES` | `20` | Maximum number of queries processed in parallel |
+| `--concurrent-downloads` | `CONCURRENT_DOWNLOADS` | `3` | Maximum number of concurrent chunk downloads |
+| `--query-threads` | `QUERY_THREADS` | (CPU count) | Threads used by the query engine |
+| `--assignment-url` | `ASSIGNMENT_URL` | network-dependent | URL of the chunk assignment / network state |
+
+Network selection and boot nodes come from the transport arguments (see `--help`). When the network is set to `mainnet` or `tethys`, default boot nodes and the assignment URL are filled in automatically.
+
+Run `sqd-worker --help` for the full list of options.
+
+## HTTP endpoints
+
+The HTTP server (on `--prometheus-port`) exposes:
+
+- `GET /worker/status`: JSON reporting the number of chunks available and downloading.
+- `GET /worker/peer-id`: the worker's libp2p peer ID.
+- `GET /metrics`: Prometheus metrics in OpenMetrics text format.
+
+## Documentation
+
+- SQD docs: https://docs.sqd.dev
+- SQD Network: https://docs.sqd.dev/en/network
+- Worker setup: https://docs.sqd.dev/subsquid-network/participate/worker/
+
+## License
+
+AGPL-3.0-or-later. See [LICENSE.md](LICENSE.md).


### PR DESCRIPTION
Expands the README for the SQD Network worker node into a factual, plainly-written document.

## What I confirmed (from the actual files)

- **Purpose** (`Cargo.toml`, `src/main.rs`, `src/cli.rs`, existing `README.md`): Rust implementation of the SQD Network worker node. Crate name `sqd-worker`, version 2.12.0, edition 2021. Downloads its assigned data-lake chunks from persistent storage (S3) and serves queries that reference those chunks. Replaces the previous Python version (subsquid/archive.py).
- **P2P transport** (`src/main.rs`, `src/cli.rs`): joins the network over a libp2p QUIC transport with a peer ID; `mainnet`/`tethys` networks have default boot nodes and assignment URLs filled in automatically.
- **Query engine** (`Cargo.toml` deps: `polars`, `sqd-query`, `sqd-polars`; `src/main.rs` sets `POLARS_MAX_THREADS`): queries run against local data using Polars and the SQD query crate.
- **HTTP endpoints** (`src/http_server.rs`): `GET /worker/status`, `GET /worker/peer-id`, `GET /metrics` (OpenMetrics text).
- **CLI options** (`src/cli.rs`): documented `--data-dir`, `--prometheus-port` (default 8000), `--p2p-port`/`LISTEN_PORT` (default 12345), `--public-ip`, `--parallel-queries` (20), `--concurrent-downloads` (3), `--query-threads`, `--assignment-url`.
- **Build** (`rust-toolchain.toml` = Rust 1.89; `Dockerfile`): `cargo build --release` produces `target/release/sqd-worker`; Docker build uses cargo-chef and needs `protobuf-compiler`, `pkg-config`, `libssl-dev`, `libsqlite3-dev`.
- **License** (`Cargo.toml`, `LICENSE.md`): AGPL-3.0-or-later.

## Style

No marketing language, no em dashes, "onchain" kept as one word (not used in body), no "ship" verb. Only states what the source files show.

## Links (all verified 200)

- https://docs.sqd.dev
- https://docs.sqd.dev/en/network
- https://docs.sqd.dev/subsquid-network/participate/worker/
- https://sqd.dev/network
- https://github.com/subsquid/sqd-network
- https://github.com/subsquid/data
- https://github.com/subsquid/archive.py/tree/master
- https://github.com/subsquid/specs/tree/main/network-rfc
- https://pola.rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)