### PR TITLE
Net 685 assignment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [features]
 query-tracing = ["sqd-query/max_level_trace"]
+mvcc-chunks = []
 
 [dependencies]
 anyhow = "1.0"

--- a/src/controller/assignments.rs
+++ b/src/controller/assignments.rs
@@ -7,9 +7,19 @@ use sqd_contract_client::PeerId;
 use tokio::time::MissedTickBehavior;
 
 pub struct AssignmentUpdate {
-    pub assignment: sqd_assignments::Assignment,
     pub id: String,
+    pub fb_url_v1: String,
     pub _effective_from: u64,
+}
+
+pub fn new_reqwest_client(timeout: Duration, peer_id: PeerId) -> reqwest::Client {
+    let version = env!("CARGO_PKG_VERSION");
+    reqwest::Client::builder()
+        .user_agent(format!("SQD Worker/{version} {peer_id}"))
+        .timeout(timeout)
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap()
 }
 
 pub fn new_assignments_stream(
@@ -22,13 +32,7 @@ pub fn new_assignments_stream(
     let mut timer = tokio::time::interval(frequency);
     timer.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
-    let version = env!("CARGO_PKG_VERSION");
-    let reqwest_client = reqwest::Client::builder()
-        .user_agent(format!("SQD Worker/{version} {peer_id}"))
-        .timeout(timeout)
-        .redirect(reqwest::redirect::Policy::none())
-        .build()
-        .unwrap();
+    let reqwest_client = new_reqwest_client(timeout, peer_id);
 
     let mut last_id = None;
 
@@ -69,22 +73,17 @@ async fn update_assignment(
         return anyhow::Ok(None);
     }
 
-    tracing::debug!("Downloading assignment \"{}\"", assignment_id);
-    let assignment = fetch_assignment(
-        &network_state
-            .assignment
-            .fb_url_v1
-            .ok_or(anyhow::anyhow!("Missing fb_url_v1"))?,
-        &reqwest_client,
-    )
-    .await?;
+    let fb_url_v1 = network_state
+        .assignment
+        .fb_url_v1
+        .ok_or_else(|| anyhow::anyhow!("Missing fb_url_v1"))?;
     *last_id = Some(assignment_id.clone());
 
-    tracing::debug!("Downloaded assignment \"{}\"", assignment_id);
+    tracing::debug!("Discovered assignment \"{}\"", assignment_id);
 
     Ok(Some(AssignmentUpdate {
-        assignment,
         id: assignment_id,
+        fb_url_v1,
         _effective_from: network_state.assignment.effective_from,
     }))
 }
@@ -98,7 +97,7 @@ async fn fetch_network_state(
     Ok(network_state)
 }
 
-async fn fetch_assignment(
+pub async fn fetch_assignment(
     url: &str,
     reqwest_client: &reqwest::Client,
 ) -> anyhow::Result<sqd_assignments::Assignment> {

--- a/src/controller/p2p.rs
+++ b/src/controller/p2p.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "mvcc-chunks")]
 use std::collections::VecDeque;
 use std::{env, sync::Arc, time::Duration};
 
@@ -44,7 +43,6 @@ const DEFAULT_BACKOFF: Duration = Duration::from_secs(1);
 const LOGS_KEEP_DURATION: Duration = Duration::from_secs(3600 * 2);
 const LOGS_CLEANUP_INTERVAL: Duration = Duration::from_secs(60);
 const STATUS_UPDATE_INTERVAL: Duration = Duration::from_secs(60);
-#[cfg(feature = "mvcc-chunks")]
 const MAX_PENDING_ASSIGNMENTS: usize = 5;
 // TODO: find out why the margin is required
 const MAX_LOGS_SIZE: usize =
@@ -226,54 +224,6 @@ impl<EventStream: Stream<Item = WorkerEvent> + Send + 'static> P2PController<Eve
         cancellation_token: CancellationToken,
         assignment_check_interval: Duration,
     ) {
-        #[cfg(feature = "mvcc-chunks")]
-        {
-            self.run_ordered_assignments_loop(cancellation_token, assignment_check_interval)
-                .await;
-        }
-
-        #[cfg(not(feature = "mvcc-chunks"))]
-        {
-            self.run_legacy_assignments_loop(cancellation_token, assignment_check_interval)
-                .await;
-        }
-    }
-
-    #[cfg(not(feature = "mvcc-chunks"))]
-    async fn run_legacy_assignments_loop(
-        &self,
-        cancellation_token: CancellationToken,
-        assignment_check_interval: Duration,
-    ) {
-        super::assignments::new_assignments_stream(
-            self.assignment_url.clone(),
-            assignment_check_interval,
-            self.assignment_fetch_timeout,
-            self.assignment_fetch_max_delay,
-            self.worker_id,
-        )
-        .take_until(cancellation_token.cancelled_owned())
-        .for_each(|update| async move {
-            let worker = self.worker.clone();
-            let keypair = self.keypair.clone();
-            let id = update.id.clone();
-            tokio::task::spawn_blocking(move || {
-                worker.register_assignment(update.assignment, update.id, &keypair);
-            })
-            .instrument(tracing::info_span!("set_assignment", id))
-            .await
-            .expect("register_assignment shouldn't panic");
-        })
-        .await;
-        info!("Assignment processing task finished");
-    }
-
-    #[cfg(feature = "mvcc-chunks")]
-    async fn run_ordered_assignments_loop(
-        &self,
-        cancellation_token: CancellationToken,
-        assignment_check_interval: Duration,
-    ) {
         let mut assignments = Box::pin(
             super::assignments::new_assignments_stream(
                 self.assignment_url.clone(),
@@ -285,40 +235,85 @@ impl<EventStream: Stream<Item = WorkerEvent> + Send + 'static> P2PController<Eve
             .take_until(cancellation_token.clone().cancelled_owned())
             .fuse(),
         );
+        let assignment_client =
+            super::assignments::new_reqwest_client(self.assignment_fetch_timeout, self.worker_id);
         let mut pending: VecDeque<super::assignments::AssignmentUpdate> = VecDeque::new();
+        #[cfg(feature = "mvcc-chunks")]
         let mut processing_id: Option<String> = None;
+        #[cfg(not(feature = "mvcc-chunks"))]
+        let processing_id: Option<String> = None;
 
-        loop {
+        'assignments: loop {
             if processing_id.is_none() {
                 if let Some(update) = pending.pop_front() {
+                    tracing::debug!("Downloading assignment \"{}\"", update.id);
+                    let assignment = match super::assignments::fetch_assignment(
+                        &update.fb_url_v1,
+                        &assignment_client,
+                    )
+                    .await
+                    {
+                        Ok(assignment) => assignment,
+                        Err(e) => {
+                            warn!(assignment_id = %update.id, error = %e, "Failed to download assignment");
+                            let retry_delay = tokio::time::sleep(DEFAULT_BACKOFF);
+                            tokio::pin!(retry_delay);
+                            let mut skip_retry = false;
+                            loop {
+                                tokio::select! {
+                                    next_update = assignments.next() => {
+                                        let Some(next_update) = next_update else {
+                                            break 'assignments;
+                                        };
+                                        if push_pending_assignment(&mut pending, next_update) {
+                                            skip_retry = true;
+                                        }
+                                    }
+                                    _ = &mut retry_delay => break,
+                                    _ = cancellation_token.cancelled() => break 'assignments,
+                                }
+                            }
+                            if !skip_retry {
+                                requeue_pending_assignment(&mut pending, update);
+                            }
+                            continue;
+                        }
+                    };
+                    tracing::debug!("Downloaded assignment \"{}\"", update.id);
+
                     let worker = self.worker.clone();
                     let keypair = self.keypair.clone();
                     let id = update.id.clone();
                     let registered = tokio::task::spawn_blocking(move || {
-                        worker.register_assignment(update.assignment, update.id, &keypair)
+                        worker.register_assignment(assignment, update.id, &keypair)
                     })
                     .instrument(tracing::info_span!("set_assignment", id))
                     .await
                     .expect("register_assignment shouldn't panic");
+
+                    #[cfg(feature = "mvcc-chunks")]
                     if registered {
                         processing_id = Some(id);
                     }
+                    #[cfg(not(feature = "mvcc-chunks"))]
+                    let _ = registered;
+
                     continue;
                 }
             }
 
+            #[cfg(feature = "mvcc-chunks")]
             match processing_id.clone() {
                 Some(id) => {
                     tokio::select! {
                         update = assignments.next() => {
                             let Some(update) = update else {
-                                let _ = self
-                                    .worker
-                                    .wait_until_assignment_applied(&id, cancellation_token.clone())
-                                    .await;
                                 break;
                             };
-                            push_pending_assignment(&mut pending, update);
+                            if push_pending_assignment(&mut pending, update) {
+                                warn!(assignment_id = %id, "Skipping current assignment because assignment queue exceeded {MAX_PENDING_ASSIGNMENTS}");
+                                processing_id = None;
+                            }
                         }
                         applied = self.worker.wait_until_assignment_applied(&id, cancellation_token.clone()) => {
                             if !applied {
@@ -339,6 +334,17 @@ impl<EventStream: Stream<Item = WorkerEvent> + Send + 'static> P2PController<Eve
                         _ = cancellation_token.cancelled() => break,
                     }
                 }
+            }
+
+            #[cfg(not(feature = "mvcc-chunks"))]
+            tokio::select! {
+                update = assignments.next() => {
+                    let Some(update) = update else {
+                        break;
+                    };
+                    push_pending_assignment(&mut pending, update);
+                }
+                _ = cancellation_token.cancelled() => break,
             }
         }
         info!("Assignment processing task finished");
@@ -767,24 +773,60 @@ async fn get_worker_status(
     }
 }
 
-#[cfg(feature = "mvcc-chunks")]
 fn push_pending_assignment(
     pending: &mut VecDeque<super::assignments::AssignmentUpdate>,
     update: super::assignments::AssignmentUpdate,
-) {
+) -> bool {
     if let Some(skipped) = push_pending_item(pending, update) {
         warn!(
             "Skipping {skipped} pending assignments because assignment queue exceeded {MAX_PENDING_ASSIGNMENTS}"
         );
+        true
+    } else {
+        false
     }
 }
 
-#[cfg(feature = "mvcc-chunks")]
 fn push_pending_item<T>(pending: &mut VecDeque<T>, item: T) -> Option<usize> {
     pending.push_back(item);
+    #[cfg(feature = "mvcc-chunks")]
     if pending.len() > MAX_PENDING_ASSIGNMENTS {
         Some(keep_only_latest_pending_assignment(pending))
     } else {
+        None
+    }
+
+    #[cfg(not(feature = "mvcc-chunks"))]
+    {
+        None
+    }
+}
+
+fn requeue_pending_assignment(
+    pending: &mut VecDeque<super::assignments::AssignmentUpdate>,
+    update: super::assignments::AssignmentUpdate,
+) -> bool {
+    if let Some(skipped) = requeue_pending_item(pending, update) {
+        warn!(
+            "Skipping {skipped} pending assignments because assignment queue exceeded {MAX_PENDING_ASSIGNMENTS}"
+        );
+        true
+    } else {
+        false
+    }
+}
+
+fn requeue_pending_item<T>(pending: &mut VecDeque<T>, item: T) -> Option<usize> {
+    pending.push_front(item);
+    #[cfg(feature = "mvcc-chunks")]
+    if pending.len() > MAX_PENDING_ASSIGNMENTS {
+        Some(keep_only_latest_pending_assignment(pending))
+    } else {
+        None
+    }
+
+    #[cfg(not(feature = "mvcc-chunks"))]
+    {
         None
     }
 }
@@ -849,5 +891,15 @@ mod tests {
             pending.into_iter().collect::<Vec<_>>(),
             (1..=MAX_PENDING_ASSIGNMENTS).collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn failed_assignment_requeue_overflow_keeps_latest_pending_assignment() {
+        let mut pending = VecDeque::from([2, 3, 4, 5, 6]);
+
+        let skipped = requeue_pending_item(&mut pending, 1);
+
+        assert_eq!(skipped, Some(5));
+        assert_eq!(pending.into_iter().collect::<Vec<_>>(), vec![6]);
     }
 }

--- a/src/controller/p2p.rs
+++ b/src/controller/p2p.rs
@@ -663,6 +663,8 @@ async fn get_worker_status(
         current_epoch,
         #[cfg(feature = "mvcc-chunks")]
         last_applied_assignment_id: status.last_applied_assignment_id,
+        #[cfg(not(feature = "mvcc-chunks"))]
+        last_applied_assignment_id: None,
     }
 }
 

--- a/src/controller/p2p.rs
+++ b/src/controller/p2p.rs
@@ -661,8 +661,8 @@ async fn get_worker_status(
         version: WORKER_VERSION.to_string(),
         stored_bytes: Some(status.stored_bytes),
         current_epoch,
-        // Reporting the applied assignment is a separate feature (NET-685)
-        last_applied_assignment_id: None,
+        #[cfg(feature = "mvcc-chunks")]
+        last_applied_assignment_id: status.last_applied_assignment_id,
     }
 }
 

--- a/src/controller/p2p.rs
+++ b/src/controller/p2p.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "mvcc-chunks")]
+use std::collections::VecDeque;
 use std::{env, sync::Arc, time::Duration};
 
 use anyhow::{anyhow, Result};
@@ -42,6 +44,8 @@ const DEFAULT_BACKOFF: Duration = Duration::from_secs(1);
 const LOGS_KEEP_DURATION: Duration = Duration::from_secs(3600 * 2);
 const LOGS_CLEANUP_INTERVAL: Duration = Duration::from_secs(60);
 const STATUS_UPDATE_INTERVAL: Duration = Duration::from_secs(60);
+#[cfg(feature = "mvcc-chunks")]
+const MAX_PENDING_ASSIGNMENTS: usize = 5;
 // TODO: find out why the margin is required
 const MAX_LOGS_SIZE: usize =
     sqd_network_transport::protocol::MAX_LOGS_RESPONSE_SIZE as usize - 100 * 1024;
@@ -222,6 +226,25 @@ impl<EventStream: Stream<Item = WorkerEvent> + Send + 'static> P2PController<Eve
         cancellation_token: CancellationToken,
         assignment_check_interval: Duration,
     ) {
+        #[cfg(feature = "mvcc-chunks")]
+        {
+            self.run_ordered_assignments_loop(cancellation_token, assignment_check_interval)
+                .await;
+        }
+
+        #[cfg(not(feature = "mvcc-chunks"))]
+        {
+            self.run_legacy_assignments_loop(cancellation_token, assignment_check_interval)
+                .await;
+        }
+    }
+
+    #[cfg(not(feature = "mvcc-chunks"))]
+    async fn run_legacy_assignments_loop(
+        &self,
+        cancellation_token: CancellationToken,
+        assignment_check_interval: Duration,
+    ) {
         super::assignments::new_assignments_stream(
             self.assignment_url.clone(),
             assignment_check_interval,
@@ -242,6 +265,82 @@ impl<EventStream: Stream<Item = WorkerEvent> + Send + 'static> P2PController<Eve
             .expect("register_assignment shouldn't panic");
         })
         .await;
+        info!("Assignment processing task finished");
+    }
+
+    #[cfg(feature = "mvcc-chunks")]
+    async fn run_ordered_assignments_loop(
+        &self,
+        cancellation_token: CancellationToken,
+        assignment_check_interval: Duration,
+    ) {
+        let mut assignments = Box::pin(
+            super::assignments::new_assignments_stream(
+                self.assignment_url.clone(),
+                assignment_check_interval,
+                self.assignment_fetch_timeout,
+                self.assignment_fetch_max_delay,
+                self.worker_id,
+            )
+            .take_until(cancellation_token.clone().cancelled_owned())
+            .fuse(),
+        );
+        let mut pending: VecDeque<super::assignments::AssignmentUpdate> = VecDeque::new();
+        let mut processing_id: Option<String> = None;
+
+        loop {
+            if processing_id.is_none() {
+                if let Some(update) = pending.pop_front() {
+                    let worker = self.worker.clone();
+                    let keypair = self.keypair.clone();
+                    let id = update.id.clone();
+                    let registered = tokio::task::spawn_blocking(move || {
+                        worker.register_assignment(update.assignment, update.id, &keypair)
+                    })
+                    .instrument(tracing::info_span!("set_assignment", id))
+                    .await
+                    .expect("register_assignment shouldn't panic");
+                    if registered {
+                        processing_id = Some(id);
+                    }
+                    continue;
+                }
+            }
+
+            match processing_id.clone() {
+                Some(id) => {
+                    tokio::select! {
+                        update = assignments.next() => {
+                            let Some(update) = update else {
+                                let _ = self
+                                    .worker
+                                    .wait_until_assignment_applied(&id, cancellation_token.clone())
+                                    .await;
+                                break;
+                            };
+                            push_pending_assignment(&mut pending, update);
+                        }
+                        applied = self.worker.wait_until_assignment_applied(&id, cancellation_token.clone()) => {
+                            if !applied {
+                                break;
+                            }
+                            processing_id = None;
+                        }
+                    }
+                }
+                None => {
+                    tokio::select! {
+                        update = assignments.next() => {
+                            let Some(update) = update else {
+                                break;
+                            };
+                            push_pending_assignment(&mut pending, update);
+                        }
+                        _ = cancellation_token.cancelled() => break,
+                    }
+                }
+            }
+        }
         info!("Assignment processing task finished");
     }
 
@@ -668,6 +767,39 @@ async fn get_worker_status(
     }
 }
 
+#[cfg(feature = "mvcc-chunks")]
+fn push_pending_assignment(
+    pending: &mut VecDeque<super::assignments::AssignmentUpdate>,
+    update: super::assignments::AssignmentUpdate,
+) {
+    if let Some(skipped) = push_pending_item(pending, update) {
+        warn!(
+            "Skipping {skipped} pending assignments because assignment queue exceeded {MAX_PENDING_ASSIGNMENTS}"
+        );
+    }
+}
+
+#[cfg(feature = "mvcc-chunks")]
+fn push_pending_item<T>(pending: &mut VecDeque<T>, item: T) -> Option<usize> {
+    pending.push_back(item);
+    if pending.len() > MAX_PENDING_ASSIGNMENTS {
+        Some(keep_only_latest_pending_assignment(pending))
+    } else {
+        None
+    }
+}
+
+#[cfg(feature = "mvcc-chunks")]
+fn keep_only_latest_pending_assignment<T>(pending: &mut VecDeque<T>) -> usize {
+    let latest = pending
+        .pop_back()
+        .expect("pending queue was just checked as non-empty");
+    let skipped = pending.len();
+    pending.clear();
+    pending.push_back(latest);
+    skipped
+}
+
 fn check_peer_id(peer_id: PeerId, filename: PathBuf) {
     use std::fs::File;
     use std::io::{Read, Write};
@@ -688,5 +820,34 @@ fn check_peer_id(peer_id: PeerId, filename: PathBuf) {
         let mut file = File::create(&filename).expect("Couldn't create peer_id file");
         file.write_all(peer_id.to_string().as_bytes())
             .expect("Couldn't write peer_id file");
+    }
+}
+
+#[cfg(all(test, feature = "mvcc-chunks"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keep_only_latest_pending_assignment_drops_intermediate_assignments() {
+        let mut pending = VecDeque::from([1, 2, 3, 4, 5, 6]);
+
+        let skipped = keep_only_latest_pending_assignment(&mut pending);
+
+        assert_eq!(skipped, 5);
+        assert_eq!(pending.into_iter().collect::<Vec<_>>(), vec![6]);
+    }
+
+    #[test]
+    fn pending_assignments_below_threshold_keep_fifo_order() {
+        let mut pending = VecDeque::new();
+
+        for assignment in 1..=MAX_PENDING_ASSIGNMENTS {
+            assert_eq!(push_pending_item(&mut pending, assignment), None);
+        }
+
+        assert_eq!(
+            pending.into_iter().collect::<Vec<_>>(),
+            (1..=MAX_PENDING_ASSIGNMENTS).collect::<Vec<_>>()
+        );
     }
 }

--- a/src/controller/worker.rs
+++ b/src/controller/worker.rs
@@ -54,8 +54,19 @@ impl Worker {
         assignment: Assignment,
         id: impl Into<String>,
         key: &Keypair,
-    ) {
-        self.state_manager.set_assignment(assignment, id, key);
+    ) -> bool {
+        self.state_manager.set_assignment(assignment, id, key)
+    }
+
+    #[cfg(feature = "mvcc-chunks")]
+    pub async fn wait_until_assignment_applied(
+        &self,
+        assignment_id: &str,
+        cancellation_token: CancellationToken,
+    ) -> bool {
+        self.state_manager
+            .wait_until_assignment_applied(assignment_id, cancellation_token)
+            .await
     }
 
     pub fn _stop_downloads(&self) {

--- a/src/storage/manager.rs
+++ b/src/storage/manager.rs
@@ -145,10 +145,7 @@ impl StateManager {
             }
             #[cfg(feature = "mvcc-chunks")]
             {
-                let fully_applied = self.state.lock().is_fully_applied();
-                if fully_applied {
-                    self.mark_current_assignment_applied();
-                }
+                self.mark_current_assignment_applied_if_ready();
             }
         }
         info!("State manager loop finished");
@@ -231,8 +228,6 @@ impl StateManager {
                 self.notify.notify_one();
             }
         }
-        #[cfg(feature = "mvcc-chunks")]
-        let fully_applied = state.is_fully_applied();
         *index = Some(datasets_index);
         drop(state);
         drop(index);
@@ -243,9 +238,7 @@ impl StateManager {
         }
 
         #[cfg(feature = "mvcc-chunks")]
-        if fully_applied {
-            self.mark_current_assignment_applied();
-        }
+        self.mark_current_assignment_applied_if_ready();
 
         match status {
             sqd_assignments::WorkerStatus::Ok => {
@@ -335,15 +328,37 @@ impl StateManager {
     }
 
     #[cfg(feature = "mvcc-chunks")]
-    fn mark_current_assignment_applied(&self) {
-        let mut assignment_application = self.assignment_application.lock();
-        let Some(current_assignment_id) = assignment_application.current_assignment_id.clone()
-        else {
-            return;
-        };
-        assignment_application.last_applied_assignment_id = Some(current_assignment_id.clone());
-        let _ = self.assignment_applied_tx.send(Some(current_assignment_id));
+    fn mark_current_assignment_applied_if_ready(&self) {
+        mark_assignment_applied_if_ready(
+            &self.state,
+            &self.assignment_application,
+            &self.assignment_applied_tx,
+        );
     }
+}
+
+// Free function (rather than a `StateManager` method) so tests can drive the exact
+// check-and-mark critical section without constructing a full `StateManager`.
+#[cfg(feature = "mvcc-chunks")]
+fn mark_assignment_applied_if_ready(
+    state: &Mutex<State>,
+    assignment_application: &Mutex<AssignmentApplicationStatus>,
+    assignment_applied_tx: &tokio::sync::watch::Sender<Option<String>>,
+) {
+    let mut assignment_application = assignment_application.lock();
+    let Some(current_assignment_id) = assignment_application.current_assignment_id.clone() else {
+        return;
+    };
+    if assignment_application.last_applied_assignment_id.as_deref()
+        == Some(current_assignment_id.as_str())
+    {
+        return;
+    }
+    if !state.lock().is_fully_applied() {
+        return;
+    }
+    assignment_application.last_applied_assignment_id = Some(current_assignment_id.clone());
+    let _ = assignment_applied_tx.send(Some(current_assignment_id));
 }
 
 #[instrument(skip_all)]
@@ -426,5 +441,80 @@ mod tests {
     fn test_join_glob() {
         // `remove_temps` depends on this behavior
         assert_eq!(PathBuf::from("a/b").join("**/*.c").as_str(), "a/b/**/*.c");
+    }
+
+    // Reproduces one specific interleaving between `set_assignment` and the state
+    // loop's periodic check that used to let a not-yet-applied assignment be reported
+    // as applied (see git history of `mark_assignment_applied_if_ready`). It is not an
+    // exhaustive test of every possible interleaving, just this one.
+    #[cfg(feature = "mvcc-chunks")]
+    #[test]
+    fn does_not_misattribute_applied_state_to_a_newer_assignment() {
+        use std::sync::Arc;
+
+        use parking_lot::Mutex;
+
+        use super::{mark_assignment_applied_if_ready, AssignmentApplicationStatus, State};
+        use crate::types::state::{ChunkRef, ChunkSet};
+
+        let chunk = |id: &str| ChunkRef {
+            dataset: Arc::new("ds".to_owned()),
+            chunk: Arc::from(id),
+        };
+        let chunk_a = chunk("a");
+        let chunk_b = chunk("b");
+
+        // Assignment A only needs `chunk_a`, which is already available, and is
+        // already marked as applied (steady state before the race begins).
+        let state = Mutex::new(State::new([chunk_a.clone()].into_iter().collect()));
+        let assignment_application = Mutex::new(AssignmentApplicationStatus {
+            current_assignment_id: Some("A".to_owned()),
+            last_applied_assignment_id: Some("A".to_owned()),
+        });
+        let (assignment_applied_tx, assignment_applied_rx) =
+            tokio::sync::watch::channel(Some("A".to_owned()));
+
+        // Step 1: `set_assignment(B)` updates the desired chunks first. B additionally
+        // needs `chunk_b`, which isn't available yet, so state stops being fully applied.
+        let desired: ChunkSet = [chunk_a.clone(), chunk_b.clone()].into_iter().collect();
+        state.lock().set_desired_chunks(desired);
+        assert!(!state.lock().is_fully_applied());
+
+        // Step 2: the state loop's own check races in before `current_assignment_id`
+        // has been updated to B. `current_assignment_id` is still A, which is already
+        // marked applied, so this must be a no-op.
+        mark_assignment_applied_if_ready(&state, &assignment_application, &assignment_applied_tx);
+        assert_eq!(
+            assignment_application.lock().last_applied_assignment_id,
+            Some("A".to_owned())
+        );
+
+        // Step 3: `set_assignment` now points `current_assignment_id` at B.
+        assignment_application.lock().current_assignment_id = Some("B".to_owned());
+
+        // Step 4: `set_assignment`'s own post-update check runs. `chunk_b` is still
+        // missing, so B must NOT be marked applied here. Before the fix, a
+        // `fully_applied` bool captured back in step 1 (still `true`, for A) would
+        // have been reused here and wrongly marked B applied.
+        mark_assignment_applied_if_ready(&state, &assignment_application, &assignment_applied_tx);
+        assert_eq!(
+            assignment_application.lock().last_applied_assignment_id,
+            Some("A".to_owned()),
+            "B must not be marked applied while chunk_b is still missing"
+        );
+        assert_eq!(*assignment_applied_rx.borrow(), Some("A".to_owned()));
+
+        // Step 5: `chunk_b` finishes downloading, so B genuinely becomes fully applied.
+        state.lock().take_next_download();
+        state.lock().complete_download(&chunk_b, true);
+        assert!(state.lock().is_fully_applied());
+
+        // Step 6: only now should B be marked applied.
+        mark_assignment_applied_if_ready(&state, &assignment_application, &assignment_applied_tx);
+        assert_eq!(
+            assignment_application.lock().last_applied_assignment_id,
+            Some("B".to_owned())
+        );
+        assert_eq!(*assignment_applied_rx.borrow(), Some("B".to_owned()));
     }
 }

--- a/src/storage/manager.rs
+++ b/src/storage/manager.rs
@@ -30,6 +30,8 @@ pub struct StateManager {
     fs: LocalFs,
     datasets_index: Mutex<Option<DatasetsIndex>>,
     state: Mutex<State>,
+    #[cfg(feature = "mvcc-chunks")]
+    assignment_application: Mutex<AssignmentApplicationStatus>,
     notify: tokio::sync::Notify,
     concurrent_downloads: usize,
     worker_id: PeerId,
@@ -40,6 +42,15 @@ pub struct Status {
     pub unavailability_map: Vec<bool>,
     pub stored_bytes: u64,
     pub assignment_id: Option<String>,
+    #[cfg(feature = "mvcc-chunks")]
+    pub last_applied_assignment_id: Option<String>,
+}
+
+#[cfg(feature = "mvcc-chunks")]
+#[derive(Debug, Default)]
+struct AssignmentApplicationStatus {
+    current_assignment_id: Option<String>,
+    last_applied_assignment_id: Option<String>,
 }
 
 impl StateManager {
@@ -61,6 +72,8 @@ impl StateManager {
             worker_id,
             notify: tokio::sync::Notify::new(),
             datasets_index: Mutex::new(None),
+            #[cfg(feature = "mvcc-chunks")]
+            assignment_application: Mutex::new(AssignmentApplicationStatus::default()),
             args,
         })
     }
@@ -121,6 +134,8 @@ impl StateManager {
                     break;
                 }
             }
+            #[cfg(feature = "mvcc-chunks")]
+            self.update_last_applied_assignment();
         }
         info!("State manager loop finished");
     }
@@ -140,6 +155,12 @@ impl StateManager {
                 unavailability_map: Default::default(),
                 stored_bytes,
                 assignment_id: None,
+                #[cfg(feature = "mvcc-chunks")]
+                last_applied_assignment_id: self
+                    .assignment_application
+                    .lock()
+                    .last_applied_assignment_id
+                    .clone(),
             };
         };
 
@@ -157,6 +178,12 @@ impl StateManager {
             unavailability_map,
             stored_bytes,
             assignment_id: Some(assignment_id.to_owned()),
+            #[cfg(feature = "mvcc-chunks")]
+            last_applied_assignment_id: self
+                .assignment_application
+                .lock()
+                .last_applied_assignment_id
+                .clone(),
         }
     }
 
@@ -166,6 +193,7 @@ impl StateManager {
         id: impl Into<String>,
         key: &Keypair,
     ) {
+        let id = id.into();
         let datasets_index = match DatasetsIndex::new(assignment, id, key) {
             Ok(result) => result,
             Err(e) => {
@@ -174,6 +202,11 @@ impl StateManager {
                 return;
             }
         };
+        #[cfg(feature = "mvcc-chunks")]
+        {
+            self.assignment_application.lock().current_assignment_id =
+                Some(datasets_index.assignment_id().to_owned());
+        }
         let status = datasets_index.status();
         let chunks: ChunkSet = datasets_index.chunks().keys().cloned().collect();
 
@@ -186,6 +219,10 @@ impl StateManager {
                 info!("Got new assignment");
                 self.notify.notify_one();
             }
+        }
+        #[cfg(feature = "mvcc-chunks")]
+        if state.is_fully_applied() {
+            self.update_last_applied_assignment_with_state(&state);
         }
         *index = Some(datasets_index);
 
@@ -251,6 +288,25 @@ impl StateManager {
             .root
             .join(dataset::encode_dataset(&chunk_ref.dataset))
             .join(chunk_ref.chunk.as_ref())
+    }
+
+    #[cfg(feature = "mvcc-chunks")]
+    fn update_last_applied_assignment(&self) {
+        let state = self.state.lock();
+        if state.is_fully_applied() {
+            self.update_last_applied_assignment_with_state(&state);
+        }
+    }
+
+    #[cfg(feature = "mvcc-chunks")]
+    fn update_last_applied_assignment_with_state(&self, state: &State) {
+        debug_assert!(state.is_fully_applied());
+        let mut assignment_application = self.assignment_application.lock();
+        let Some(current_assignment_id) = assignment_application.current_assignment_id.clone()
+        else {
+            return;
+        };
+        assignment_application.last_applied_assignment_id = Some(current_assignment_id);
     }
 }
 

--- a/src/storage/manager.rs
+++ b/src/storage/manager.rs
@@ -50,6 +50,8 @@ pub struct Status {
 #[derive(Debug, Default)]
 struct AssignmentApplicationStatus {
     current_assignment_id: Option<String>,
+    // Intentionally remains set while a newer assignment is being applied.
+    // This reports the latest fully applied assignment, not the current target.
     last_applied_assignment_id: Option<String>,
 }
 
@@ -135,7 +137,12 @@ impl StateManager {
                 }
             }
             #[cfg(feature = "mvcc-chunks")]
-            self.update_last_applied_assignment();
+            {
+                let fully_applied = self.state.lock().is_fully_applied();
+                if fully_applied {
+                    self.mark_current_assignment_applied();
+                }
+            }
         }
         info!("State manager loop finished");
     }
@@ -194,6 +201,8 @@ impl StateManager {
         key: &Keypair,
     ) {
         let id = id.into();
+        #[cfg(feature = "mvcc-chunks")]
+        let current_assignment_id = id.clone();
         let datasets_index = match DatasetsIndex::new(assignment, id, key) {
             Ok(result) => result,
             Err(e) => {
@@ -204,8 +213,7 @@ impl StateManager {
         };
         #[cfg(feature = "mvcc-chunks")]
         {
-            self.assignment_application.lock().current_assignment_id =
-                Some(datasets_index.assignment_id().to_owned());
+            self.assignment_application.lock().current_assignment_id = Some(current_assignment_id);
         }
         let status = datasets_index.status();
         let chunks: ChunkSet = datasets_index.chunks().keys().cloned().collect();
@@ -221,10 +229,15 @@ impl StateManager {
             }
         }
         #[cfg(feature = "mvcc-chunks")]
-        if state.is_fully_applied() {
-            self.update_last_applied_assignment_with_state(&state);
-        }
+        let fully_applied = state.is_fully_applied();
         *index = Some(datasets_index);
+        drop(state);
+        drop(index);
+
+        #[cfg(feature = "mvcc-chunks")]
+        if fully_applied {
+            self.mark_current_assignment_applied();
+        }
 
         match status {
             sqd_assignments::WorkerStatus::Ok => {
@@ -291,16 +304,7 @@ impl StateManager {
     }
 
     #[cfg(feature = "mvcc-chunks")]
-    fn update_last_applied_assignment(&self) {
-        let state = self.state.lock();
-        if state.is_fully_applied() {
-            self.update_last_applied_assignment_with_state(&state);
-        }
-    }
-
-    #[cfg(feature = "mvcc-chunks")]
-    fn update_last_applied_assignment_with_state(&self, state: &State) {
-        debug_assert!(state.is_fully_applied());
+    fn mark_current_assignment_applied(&self) {
         let mut assignment_application = self.assignment_application.lock();
         let Some(current_assignment_id) = assignment_application.current_assignment_id.clone()
         else {

--- a/src/storage/manager.rs
+++ b/src/storage/manager.rs
@@ -32,6 +32,8 @@ pub struct StateManager {
     state: Mutex<State>,
     #[cfg(feature = "mvcc-chunks")]
     assignment_application: Mutex<AssignmentApplicationStatus>,
+    #[cfg(feature = "mvcc-chunks")]
+    assignment_applied_tx: tokio::sync::watch::Sender<Option<String>>,
     notify: tokio::sync::Notify,
     concurrent_downloads: usize,
     worker_id: PeerId,
@@ -67,6 +69,9 @@ impl StateManager {
         let existing_chunks = load_state(&fs).await?;
         debug!("Loaded state: {:#?}", existing_chunks);
 
+        #[cfg(feature = "mvcc-chunks")]
+        let (assignment_applied_tx, _) = tokio::sync::watch::channel(None);
+
         Ok(Self {
             fs,
             state: Mutex::new(State::new(existing_chunks)),
@@ -76,6 +81,8 @@ impl StateManager {
             datasets_index: Mutex::new(None),
             #[cfg(feature = "mvcc-chunks")]
             assignment_application: Mutex::new(AssignmentApplicationStatus::default()),
+            #[cfg(feature = "mvcc-chunks")]
+            assignment_applied_tx,
             args,
         })
     }
@@ -199,7 +206,7 @@ impl StateManager {
         assignment: sqd_assignments::Assignment,
         id: impl Into<String>,
         key: &Keypair,
-    ) {
+    ) -> bool {
         let id = id.into();
         #[cfg(feature = "mvcc-chunks")]
         let current_assignment_id = id.clone();
@@ -208,13 +215,9 @@ impl StateManager {
             Err(e) => {
                 metrics::set_status(metrics::WorkerStatus::NotRegistered);
                 error!("Can not get assigned chunks: {e}");
-                return;
+                return false;
             }
         };
-        #[cfg(feature = "mvcc-chunks")]
-        {
-            self.assignment_application.lock().current_assignment_id = Some(current_assignment_id);
-        }
         let status = datasets_index.status();
         let chunks: ChunkSet = datasets_index.chunks().keys().cloned().collect();
 
@@ -233,6 +236,11 @@ impl StateManager {
         *index = Some(datasets_index);
         drop(state);
         drop(index);
+
+        #[cfg(feature = "mvcc-chunks")]
+        {
+            self.assignment_application.lock().current_assignment_id = Some(current_assignment_id);
+        }
 
         #[cfg(feature = "mvcc-chunks")]
         if fully_applied {
@@ -255,6 +263,29 @@ impl StateManager {
             sqd_assignments::WorkerStatus::UnsupportedVersion => {
                 warn!("Worker version is unsupported");
                 metrics::set_status(metrics::WorkerStatus::UnsupportedVersion);
+            }
+        }
+        true
+    }
+
+    #[cfg(feature = "mvcc-chunks")]
+    pub async fn wait_until_assignment_applied(
+        &self,
+        assignment_id: &str,
+        cancellation_token: CancellationToken,
+    ) -> bool {
+        let mut assignment_applied_rx = self.assignment_applied_tx.subscribe();
+        loop {
+            if assignment_applied_rx.borrow().as_deref() == Some(assignment_id) {
+                return true;
+            }
+            tokio::select! {
+                changed = assignment_applied_rx.changed() => {
+                    if changed.is_err() {
+                        return false;
+                    }
+                }
+                _ = cancellation_token.cancelled() => return false,
             }
         }
     }
@@ -310,7 +341,8 @@ impl StateManager {
         else {
             return;
         };
-        assignment_application.last_applied_assignment_id = Some(current_assignment_id);
+        assignment_application.last_applied_assignment_id = Some(current_assignment_id.clone());
+        let _ = self.assignment_applied_tx.send(Some(current_assignment_id));
     }
 }
 

--- a/src/storage/state.rs
+++ b/src/storage/state.rs
@@ -116,6 +116,11 @@ impl State {
         }
     }
 
+    #[cfg(any(feature = "mvcc-chunks", test))]
+    pub fn is_fully_applied(&self) -> bool {
+        self.available == self.desired && self.downloading.is_empty() && self.to_download.is_empty()
+    }
+
     pub fn get_and_lock_chunk(&mut self, dataset: DatasetId, chunk: ChunkId) -> Option<ChunkRef> {
         let chunk_ref = self.available.get(&ChunkRef { dataset, chunk }).cloned();
 
@@ -219,5 +224,40 @@ mod tests {
             state.status().desired.into_iter().collect_vec(),
             &[b.clone(), d.clone()]
         );
+        assert!(state.is_fully_applied());
+    }
+
+    #[test]
+    fn fully_applied_requires_available_desired_chunks_and_no_pending_work() {
+        let ds = Arc::new("ds".to_owned());
+        let chunk_ref = |x| ChunkRef {
+            dataset: ds.clone(),
+            chunk: Arc::from(format!(
+                "0000000000/000000000{}-000000000{}-00000000",
+                x,
+                x + 1
+            )),
+        };
+        let a = chunk_ref(0);
+        let b = chunk_ref(1);
+        let c = chunk_ref(2);
+
+        let mut state = State::new([a.clone(), b.clone()].into_iter().collect());
+        assert!(state.is_fully_applied());
+
+        state.set_desired_chunks([a.clone(), b.clone(), c.clone()].into_iter().collect());
+        assert!(!state.is_fully_applied());
+
+        assert_eq!(state.take_next_download(), Some(c.clone()));
+        assert!(!state.is_fully_applied());
+
+        state.complete_download(&c, true);
+        assert!(state.is_fully_applied());
+
+        state.set_desired_chunks([b.clone(), c.clone()].into_iter().collect());
+        assert!(!state.is_fully_applied());
+
+        assert_eq!(state.take_removals(), &[a]);
+        assert!(state.is_fully_applied());
     }
 }

--- a/src/storage/state.rs
+++ b/src/storage/state.rs
@@ -118,7 +118,14 @@ impl State {
 
     #[cfg(any(feature = "mvcc-chunks", test))]
     pub fn is_fully_applied(&self) -> bool {
-        self.available == self.desired && self.downloading.is_empty() && self.to_download.is_empty()
+        // A stale in-flight download for a chunk no longer desired does not block
+        // applying the current assignment. It will either complete as extra
+        // available data or be ignored when cancellation is reported.
+        self.to_download.is_empty()
+            && self
+                .desired
+                .iter()
+                .all(|chunk| self.available.contains(chunk))
     }
 
     pub fn get_and_lock_chunk(&mut self, dataset: DatasetId, chunk: ChunkId) -> Option<ChunkRef> {
@@ -228,7 +235,7 @@ mod tests {
     }
 
     #[test]
-    fn fully_applied_requires_available_desired_chunks_and_no_pending_work() {
+    fn fully_applied_requires_desired_chunks_to_be_available() {
         let ds = Arc::new("ds".to_owned());
         let chunk_ref = |x| ChunkRef {
             dataset: ds.clone(),
@@ -255,9 +262,35 @@ mod tests {
         assert!(state.is_fully_applied());
 
         state.set_desired_chunks([b.clone(), c.clone()].into_iter().collect());
-        assert!(!state.is_fully_applied());
+        assert!(state.is_fully_applied());
 
         assert_eq!(state.take_removals(), &[a]);
+        assert!(state.is_fully_applied());
+    }
+
+    #[test]
+    fn fully_applied_ignores_stale_downloads() {
+        let ds = Arc::new("ds".to_owned());
+        let chunk_ref = |x| ChunkRef {
+            dataset: ds.clone(),
+            chunk: Arc::from(format!(
+                "0000000000/000000000{}-000000000{}-00000000",
+                x,
+                x + 1
+            )),
+        };
+        let a = chunk_ref(0);
+        let b = chunk_ref(1);
+        let c = chunk_ref(2);
+
+        let mut state = State::new([a.clone(), b.clone()].into_iter().collect());
+        state.set_desired_chunks([a.clone(), b.clone(), c.clone()].into_iter().collect());
+
+        assert_eq!(state.take_next_download(), Some(c.clone()));
+        assert!(!state.is_fully_applied());
+
+        state.set_desired_chunks([a, b].into_iter().collect());
+        assert!(state.get_stale_downloads().contains(&c));
         assert!(state.is_fully_applied());
     }
 }


### PR DESCRIPTION
### Summary

Implements the worker-side part of NET-685 behind the mvcc-chunks feature flag.

Workers now track when the current assignment has been fully applied and include last_applied_assignment_id in heartbeats once all required chunks are available and pending removals/downloads are complete.

###   Notes

  - last_applied_assignment_id is an opaque String.
  - Worker does not parse, compare, or order assignment IDs.
  - Assignment ordering remains scheduler-owned under NET-686.
  - While running, workers apply assignments in arrival order. If more than 5 assignments are queued, queued intermediate assignments are skipped and the worker advances to the newest pending assignment; the assignment currently being applied is never interrupted.
  - The previously applied assignment intentionally remains reported while a newer assignment is still being applied.
  - Requires the sqd-network proto change that adds last_applied_assignment_id to Heartbeat.

###   Validation

  - cargo test -p sqd-worker storage::state
  - cargo check -p sqd-worker
  - cargo check -p sqd-worker --features mvcc-chunks --config 'patch."https://github.com/subsquid/sqd-network.git".sqd-messages.path="../sqd-network/crates/messages"'

  - cargo test -p sqd-worker storage::state --features mvcc-chunks --config 'patch."https://github.com/subsquid/sqd-network.git".sqd-messages.path="../sqd-network/crates/messages"'
  - cargo check -p sqd-worker --locked
  - git diff --check
