### PR TITLE
feat: Refresh heartbeat promptly when an assignment is applied

### DIFF
--- a/src/controller/p2p.rs
+++ b/src/controller/p2p.rs
@@ -769,9 +769,10 @@ async fn wait_for_assignment_applied(
     applied: &mut Option<tokio::sync::watch::Receiver<Option<String>>>,
 ) {
     match applied {
-        Some(applied) => {
-            let _ = applied.changed().await;
-        }
+        Some(applied) => applied
+            .changed()
+            .await
+            .expect("assignment_applied sender outlives the status loop"),
         None => std::future::pending::<()>().await,
     }
 }

--- a/src/controller/p2p.rs
+++ b/src/controller/p2p.rs
@@ -370,14 +370,23 @@ impl<EventStream: Stream<Item = WorkerEvent> + Send + 'static> P2PController<Eve
     ) {
         let mut timer = tokio::time::interval(interval);
         timer.set_missed_tick_behavior(MissedTickBehavior::Delay);
-        IntervalStream::new(timer)
-            .take_until(cancellation_token.cancelled_owned())
-            .for_each(|_| async move {
-                let status =
-                    get_worker_status(&self.worker, self.allocations_checker.current_epoch()).await;
-                *self.worker_status.write() = status;
-            })
-            .await;
+        // Refresh on the periodic timer and, additionally, when an assignment
+        // becomes fully applied (prompt last_applied_assignment_id, via the
+        // existing applied signal). `None` in non-mvcc builds (no applied concept).
+        #[cfg(feature = "mvcc-chunks")]
+        let mut assignment_applied = Some(self.worker.subscribe_assignment_applied());
+        #[cfg(not(feature = "mvcc-chunks"))]
+        let mut assignment_applied: Option<tokio::sync::watch::Receiver<Option<String>>> = None;
+        loop {
+            tokio::select! {
+                _ = timer.tick() => {}
+                _ = wait_for_assignment_applied(&mut assignment_applied) => {}
+                _ = cancellation_token.cancelled() => break,
+            }
+            let status =
+                get_worker_status(&self.worker, self.allocations_checker.current_epoch()).await;
+            *self.worker_status.write() = status;
+        }
         info!("Status update task finished");
     }
 
@@ -750,6 +759,20 @@ impl<EventStream: Stream<Item = WorkerEvent> + Send + 'static> P2PController<Eve
         );
         self.transport_handle.send_logs(msg, resp_chan)?;
         Ok(())
+    }
+}
+
+// Resolves when the current assignment becomes fully applied. `applied` is `None`
+// in non-mvcc builds (no "applied" concept), so it never resolves and the status
+// loop relies on the periodic timer only.
+async fn wait_for_assignment_applied(
+    applied: &mut Option<tokio::sync::watch::Receiver<Option<String>>>,
+) {
+    match applied {
+        Some(applied) => {
+            let _ = applied.changed().await;
+        }
+        None => std::future::pending::<()>().await,
     }
 }
 

--- a/src/controller/p2p.rs
+++ b/src/controller/p2p.rs
@@ -372,7 +372,7 @@ impl<EventStream: Stream<Item = WorkerEvent> + Send + 'static> P2PController<Eve
         timer.set_missed_tick_behavior(MissedTickBehavior::Delay);
         // Refresh on the periodic timer and, additionally, when an assignment
         // becomes fully applied (prompt last_applied_assignment_id, via the
-        // existing applied signal). `None` in non-mvcc builds (no applied concept).
+        // existing applied signal). 
         #[cfg(feature = "mvcc-chunks")]
         let mut assignment_applied = Some(self.worker.subscribe_assignment_applied());
         #[cfg(not(feature = "mvcc-chunks"))]

--- a/src/controller/p2p.rs
+++ b/src/controller/p2p.rs
@@ -372,7 +372,7 @@ impl<EventStream: Stream<Item = WorkerEvent> + Send + 'static> P2PController<Eve
         timer.set_missed_tick_behavior(MissedTickBehavior::Delay);
         // Refresh on the periodic timer and, additionally, when an assignment
         // becomes fully applied (prompt last_applied_assignment_id, via the
-        // existing applied signal). 
+        // existing applied signal).
         #[cfg(feature = "mvcc-chunks")]
         let mut assignment_applied = Some(self.worker.subscribe_assignment_applied());
         #[cfg(not(feature = "mvcc-chunks"))]

--- a/src/controller/worker.rs
+++ b/src/controller/worker.rs
@@ -77,6 +77,13 @@ impl Worker {
         self.state_manager.current_status().await
     }
 
+    /// Subscribe to the "assignment fully applied" signal, so callers can refresh
+    /// the reported status promptly when last_applied_assignment_id advances.
+    #[cfg(feature = "mvcc-chunks")]
+    pub fn subscribe_assignment_applied(&self) -> tokio::sync::watch::Receiver<Option<String>> {
+        self.state_manager.subscribe_assignment_applied()
+    }
+
     pub async fn run_query(
         &self,
         query_str: &str,

--- a/src/storage/manager.rs
+++ b/src/storage/manager.rs
@@ -151,6 +151,15 @@ impl StateManager {
         info!("State manager loop finished");
     }
 
+    /// Subscribe to the "assignment fully applied" signal. The receiver observes a
+    /// change each time `last_applied_assignment_id` advances, i.e. when the current
+    /// assignment's chunks are all present. Used to refresh the reported status
+    /// promptly on application instead of waiting for the periodic status timer.
+    #[cfg(feature = "mvcc-chunks")]
+    pub fn subscribe_assignment_applied(&self) -> tokio::sync::watch::Receiver<Option<String>> {
+        self.assignment_applied_tx.subscribe()
+    }
+
     #[instrument(skip_all)]
     pub async fn current_status(&self) -> Status {
         let status = self.state.lock().status();


### PR DESCRIPTION
The worker served heartbeat/status from a cache refreshed only on a fixed 60s timer, so last_applied_assignment_id could lag up to a minute after an assignment became fully applied. Have the status loop also refresh when the existing assignment_applied_tx signal fires (mvcc-chunks only, where the "applied" concept exists), in addition to the periodic timer.