### PR TITLE
docs(spec): behavioral specification suite with conformance program

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -1,0 +1,19 @@
+name: spec
+on:
+  pull_request:
+    paths: ["spec/**"]
+  push:
+    branches: [master]
+    paths: ["spec/**"]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # freshness checks need full history
+      - name: Annotate (non-gating, warnings included)
+        run: python3 spec/tools/check_spec.py spec --format github || true
+      - name: Gate on errors
+        run: python3 spec/tools/check_spec.py spec

--- a/spec/01-overview.md
+++ b/spec/01-overview.md
@@ -1,0 +1,94 @@
+# 01 — Overview
+
+## What it is
+
+The worker is one node of a horizontally-sharded, decentralized data lake. The network's
+datasets are split into immutable **chunks**; a network **scheduler** publishes an
+**assignment** mapping chunks to workers. Each worker continuously reconciles its local
+**chunk store** against its slice of the assignment — downloading newly assigned chunks
+from a **data origin**, deleting unassigned ones — and serves **queries** from
+**portals** against the chunks it holds.
+
+The hot path the system exists for: a portal sends a signed query naming one dataset,
+one chunk, and a block range; the worker validates and meters it, evaluates it against
+the local chunk data, and returns a signed result whose `last_block` tells the portal
+how far it got. Everything else — assignment intake, downloads, eviction, status
+reporting, log delivery — exists to keep that path serving fresh, correct data.
+
+The worker is economically accountable: each admitted query consumes **compute units
+(CU)** from the querying operator's per-epoch allocation, and every admitted query
+produces a log record that collectors pull as evidence of work performed.
+
+## Actors
+
+| Actor | Direction | Role | Verified how |
+|---|---|---|---|
+| Portal | inbound | sends queries, receives signed results | per-query signature bound to sender identity and this worker (RP-2) |
+| Scheduler | inbound (polled) | publishes network-state and assignment documents | transport security only; document contents trusted (ADR-3) |
+| Data origin | inbound (polled) | serves chunk files named by the assignment | credentials from the assignment; payload unverified (GAP-5) |
+| Logs collector | inbound | pulls query-execution log records | network membership only; no per-request auth (GAP-22) |
+| Chain registry | inbound (polled) | epoch number, CU allocations, peer membership | trusted read |
+| Schema registry | inbound (polled) | dataset schema manifest for the dynamic engine | transport security only |
+| Operator (human) | config | runs the process, sets configuration, watches metrics | — |
+
+## Design goals
+
+- **G1 — Correct partial results.** A query response is always sound: data derives only
+  from committed chunk content, and `last_block` honestly bounds coverage. → REQ-1,
+  REQ-4, INV-21/22, RP-11.
+- **G2 — Convergent replication.** The store converges to the assignment without manual
+  intervention, atomically per chunk, safely across crashes. → REQ-2, REQ-3, LIV-1,
+  CN-1, INV-40.
+- **G3 — Metered, accountable service.** Work is charged per operator against on-chain
+  allocations, and every admitted query is provable via its log record. → REQ-21,
+  REQ-12, INV-15, INV-32.
+- **G4 — Robust residency.** No input — hostile query, malformed assignment, flaky
+  origin — terminates the process or corrupts the store. → REQ-24, FM-1, INV-36.
+- **G5 — Honest self-reporting.** Status, heartbeat, and metrics reflect real state
+  within bounded staleness. → REQ-11, REQ-13, LIV-6, INV-30/31.
+
+## Non-goals
+
+- **NG1 — Multi-chunk queries.** A query addresses exactly one chunk; cross-chunk
+  aggregation is the portal's job (ADR-12). Tests must not pin any multi-chunk behavior.
+- **NG2 — Assignment ordering.** The worker treats assignment identifiers as opaque and
+  applies assignments in arrival order; ordering and supersession semantics are
+  scheduler-owned (ADR-16).
+- **NG3 — Query-language semantics.** What a query *means* over chunk data is the
+  embedded query engines' contract, external to this spec. The worker spec constrains
+  the envelope: admission, metering, coverage, boundary emission (RP-11), size bounds, error taxonomy (see the
+  free-variable declaration in 13).
+- **NG4 — Data authenticity.** The worker does not attest that origin data is the true
+  chain history; it serves what the assignment names. Verification is a network-level
+  concern.
+- **NG5 — Multi-tenant fairness beyond CU metering.** CU metering is the only per-client
+  fairness mechanism; the worker promises no per-portal scheduling fairness (see
+  LIV-11 for the *cross-dataset* download bound, which is promised).
+
+## Trust model
+
+| Actor | Trusted with | Must never be able to cause |
+|---|---|---|
+| Portal | nothing; every query verified and metered | process termination, store corruption, unmetered work, reading another operator's data context |
+| Scheduler | store contents (it decides what the worker holds) | process termination via a malformed document (REQ-24); silent total store wipe is bounded by REQ-25 |
+| Data origin | chunk payload bytes | process termination; a bad payload may only yield per-chunk failure, never store-wide unavailability |
+| Logs collector | reading execution logs | write access to anything; unbounded resource use |
+| Chain registry | metering inputs (epoch, allocations) | process termination on unavailability; stale data degrades metering, never safety |
+| Operator | full control | — (misconfiguration SHOULD fail fast at startup, FM-50) |
+
+## Lifecycle at a glance
+
+Dataflow:
+
+```
+ scheduler ──(poll: network-state, assignment)──▶ ┌────────────┐
+ data origin ──(poll: chunk files)──────────────▶ │            │──▶ chunk store (disk)
+ chain registry ──(poll: epoch, allocations)────▶ │   WORKER   │──▶ log store (disk)
+ schema registry ──(poll: schema manifest)──────▶ │            │──▶ metrics/status (pull)
+ portal ──(query)───────────────────────────────▶ │            │──▶ signed result
+ collector ──(logs request)─────────────────────▶ └────────────┘──▶ log records
+```
+
+Chunk lifecycle (one line): `assigned → pending → downloading → available ⇄ pinned → unassigned → removed`.
+
+Process lifecycle (one line): `start → recover store (sweep residue, adopt committed chunks) → confirm on-chain registration (poll until listed; nothing is served before — FM-54) → accept queries (degraded: no assignment yet) → converge to assignment → steady serve/reconcile → shutdown (bounded drain)`.

--- a/spec/02-requirements.md
+++ b/spec/02-requirements.md
@@ -1,0 +1,170 @@
+# 02 — Requirements
+
+Home doc for `REQ` and `OQ`. Bands: REQ-1..9 core flow · REQ-10..19 management ·
+REQ-20..29 quality. Acceptance *status* lives in the matrix in
+[13-conformance-tdd.md](13-conformance-tdd.md), not here.
+
+## Core flow
+
+**REQ-1 — Serve chunk queries.** [MUST]
+Given a well-formed, authenticated query naming a dataset, a chunk the worker holds, and
+a block range, the worker returns a result computed from that chunk's committed content,
+signed by the worker, in the requested output format and compression.
+*Acceptance:* a portal-driver query against a known chunk returns a decodable, signed
+result whose content matches the reference evaluation of the same query over the same
+chunk files; every structural validator (13 §validators) passes.
+*Trace:* ADR-11, ADR-12; INV-20/21/25, RP-10..15.
+
+**REQ-2 — Acquire assigned data.** [MUST]
+The worker discovers its assignment by polling and downloads every assigned chunk it
+lacks, without operator intervention. Each chunk becomes queryable atomically — a chunk
+is either fully present and served, or absent; partially downloaded data is never
+visible.
+*Acceptance:* publish an assignment of N chunks against a stub origin; within the LIV-1
+bound the worker's heartbeat reports zero missing chunks and each chunk answers queries;
+killing the worker mid-download never yields a queryable partial chunk (CT-2).
+*Trace:* ADR-1, ADR-2; WP-10..12, CN-1, LIV-1/2, INV-40.
+
+**REQ-3 — Release unassigned data.** [MUST]
+Chunks absent from the current assignment are deleted — but never while a query is
+executing against them, and only through the explicit eviction transition.
+*Acceptance:* shrink the assignment while a long query holds the evicted chunk: the
+query completes from intact data; the chunk's space is reclaimed within P-EVICT-BOUND of
+the query's end.
+*Trace:* WP-14, RS-1/2/4, INV-11/12, LIV-4.
+
+**REQ-4 — Honest progress reporting.** [MUST]
+Every successful result carries `last_block`: the upper bound of the range actually
+covered. A truncated result (size budget reached) reports the last block included; an
+empty result reports the requested range's end. A portal resuming from
+`last_block + 1` never skips and never re-reads data.
+*Acceptance:* for a query whose full result exceeds P-RESP-BUDGET, the concatenation of
+results obtained by repeated resumption equals the reference evaluation of the whole
+range, with no overlap and no gap.
+*Trace:* ADR-4; RP-11/13, INV-22.
+
+## Management
+
+**REQ-10 — Assignment intake by polling.** [MUST]
+The worker polls the network-state document every P-ASSIGN-POLL, fetches a changed
+assignment within P-ASSIGN-FETCH-TIMEOUT, and applies it in arrival order. A fetch
+failure is retried with backoff bounded by P-ASSIGN-RETRY-MAX; a failed or inapplicable
+assignment leaves the previously applied assignment fully in force.
+*Acceptance:* against a stub scheduler, an assignment change is observable in the
+heartbeat's assignment id within P-ASSIGN-POLL + P-ASSIGN-FETCH-TIMEOUT + P-HB-INTERVAL;
+serving a corrupt document then a good one converges to the good one.
+*Trace:* ADR-1, ADR-16; WP-1..4, LIV-1, FM-10..14.
+
+**REQ-11 — Status reporting.** [MUST]
+On request, the worker reports: its version, the applied assignment id, a per-chunk
+availability map for the assignment's chunk list, stored bytes, and the current epoch.
+The report is internally coherent — all fields derive from one state snapshot — and no
+staler than P-HB-STALENESS. [Coherence is intent, currently violated: GAP-11.]
+*Acceptance:* flip the assignment while status requests stream; no response ever pairs
+assignment id A with an availability map computed for assignment B (CT-3).
+*Trace:* ADR-16; RP-21, INV-30, LIV-6, OB-1..3.
+
+**REQ-12 — Execution logging and pull delivery.** [MUST]
+Every admitted query — success or error — produces exactly one durable log record
+(identity, the original query, outcome summary, timings). Collectors pull records by
+cursor; records are retained at least P-LOGS-RETENTION. Queries rejected before
+admission produce no record (ADR-7).
+*Acceptance:* run K admitted queries, crash and restart, then pull: exactly K records
+(no loss for queries whose response was sent, modulo ADR-13's accepted crash window),
+resumable by cursor with no duplicates or gaps across pages.
+*Trace:* ADR-7, ADR-8, ADR-13; WP-16/17, RP-22, INV-23/32, CN-6.
+
+**REQ-13 — Operational transparency.** [MUST]
+The worker exposes pull-based operational metrics and a machine-readable local status
+surface sufficient to decide every liveness property in 08 from the outside
+(12 §mapping).
+*Acceptance:* every OB signal exists at the binding surface (IB-30) and moves when its
+underlying state moves; the "lying metrics" harness rule (12) passes.
+*Trace:* OB-1..14, IB-30/31.
+
+## Quality
+
+**REQ-20 — Query authentication.** [MUST]
+A query is served only if its signature verifies against the sending peer's identity,
+binds this specific worker, and its timestamp is within P-TS-WINDOW of the worker's
+clock. Responses are signed so the portal can prove result provenance.
+*Acceptance:* mutated-field, wrong-worker, expired, and unsigned queries are all
+rejected with the taxonomy's `bad_request` before any CU is spent; a valid response
+verifies against the worker's identity.
+*Trace:* RP-2, INV-25, IB-13.
+
+**REQ-21 — Compute metering.** [MUST]
+Each admitted query charges one CU against the querying operator's per-epoch allocation
+at admission; after execution, the unused fraction for a partial-range query is
+refunded. Operators without allocation, or with an exhausted budget, are rejected with a
+retry hint where one exists. An overload rejection after admission keeps the charged
+unit (ADR-6).
+*Acceptance:* CU-conservation property test: for any admitted query sequence, net spend
+per operator equals the sum of covered-fraction chips, except overload rejections which
+cost 1; rejections before admission cost 0.
+*Trace:* ADR-6, ADR-7; RP-3/4, INV-15, WP-16.
+
+**REQ-22 — Overload rejection, not collapse.** [MUST]
+Beyond declared concurrency bounds (P-Q-QUEUE, P-Q-PAR, P-REJECT-CONC), the worker sheds
+load with typed, retryable rejections carrying a P-RETRY-HINT, and recovers full service
+when pressure subsides. Resource use under flood is bounded. [P-Q-PAR enforcement is
+intent, currently violated: GAP-1.]
+*Acceptance:* a query storm at W-QPS-STORM yields only typed rejections (no stream
+resets below the reject fan-out bound, no process death, memory below P-MEM-CEIL);
+service latency recovers to the S1 SLO within LIV-8's bound after the storm.
+*Trace:* ADR-9; RP-4, LIV-8, FM-40..44, SLI-7.
+
+**REQ-23 — Crash-only chunk store.** [MUST]
+The chunk store needs no clean shutdown: after a process crash at any point, recovery
+adopts exactly the committed chunks, sweeps all transient residue, and serves queries
+with no manual repair. Power-loss durability of chunk payloads is a declared, bounded
+exception. [Payload integrity after power loss is intent, currently violated: GAP-5.]
+*Acceptance:* kill-point matrix (CT-2) over every transition: recovered available set ≡
+some committed prefix; no residue accumulates across repeated kills (RS-6).
+*Trace:* CN-3/4/5, INV-40..42, WP-15, WP-23.
+
+**REQ-24 — Hostile-input robustness.** [MUST — intent, currently violated: GAP-2, GAP-4]
+No input — query bytes, assignment document, origin payload, log request — may terminate
+the process, corrupt either store, or cause unbounded memory growth. Malformed input
+yields a typed error (queries) or a rejected-and-retried document (assignments), with an
+alarm.
+*Acceptance:* fuzz corpus over both surfaces (CT-9) and the input-fault corpus (CT-4)
+run to completion with the process alive and both stores intact.
+*Trace:* ADR-18; FM-1, FM-10..23, INV-36.
+
+**REQ-25 — Bounded reconciliation blast radius.** [SHOULD — intent, currently violated: GAP-3]
+A single assignment application SHOULD NOT delete more than the P-DEL-FLOOR fraction of
+the store without an explicit operator override; a wipe-inducing assignment is held,
+alarmed, and re-evaluated on the next poll. ⚠ pending ADR-17.
+*Acceptance:* publish an assignment dropping all chunks: the store retains its data, an
+alarm level is raised (OB-12), and a subsequent restoring assignment resumes normal
+reconciliation.
+*Trace:* ADR-17; WP-14, RS-5, FM-13.
+
+## Explicitly unspecified
+
+Tests MUST NOT pin any of the following; each is free to change without notice:
+
+- The order and timing of downloads beyond the WP-13 fairness rule; which eligible chunk
+  starts first.
+- Byte-level output of compression; anything about temporary on-disk names or the
+  encoding of dataset directory names.
+- Result byte layout beyond the format contracts in 14 (e.g. field order inside a line).
+- Relative order of log records sharing a timestamp beyond the RP-22 cursor rule.
+- Behavior when two processes share a store with the *same* identity (only the
+  different-identity case is specified, CN-9).
+- The scheduling of background maintenance between transitions, provided maintenance
+  transparency (CN-7) holds.
+
+## Open questions
+
+| OQ | Question | Blocking | Owner |
+|---|---|---|---|
+| OQ-1 | Is the availability map's bit order (worker's sorted chunk order) identical to the scheduler's assignment chunk order for suffix-forked chunks? A mismatch silently corrupts scheduler-side interpretation. | REQ-11 acceptance; IB-12 | network/scheduler team |
+| OQ-2 | The log response ceiling reserves a margin below the transport maximum (P-LOGS-RESP-MAX); why the margin is needed is unrecorded. Right-size or document. | IB-20 | worker team |
+| OQ-3 | The multi-version chunk-application feature (staged assignment tracking) is compiled out of shipped builds while tests exercise it. Ship it or retire it? | 13 matrix honesty | worker team |
+| OQ-4 | Status reports are unsigned. Is unauthenticated status by design, or should it be signed like results? | RP-21 | network team |
+| OQ-5 | The worker's log records hash the uncompressed result while the portal's records hash the compressed bytes; cross-checking will systematically mismatch. Which is canonical? | INV-23, GAP-14 | network team |
+| OQ-6 | No per-query execution deadline exists (P-Q-DEADLINE ⚠). What bound should the network promise? Portals abandon an attempt at 60 s, so the worker bound must sit strictly below (target: 55 s) for timeout verdicts to ever be observed by them. | LIV-3, GAP-8 | worker team |
+| OQ-7 | Portal fork recovery depends on distinguishing the worker's anchor-mismatch verdict, which today exists only as an unstable `server_error` message string (GAP-30, GAP-31). Promote it to a stable wire surface (error variant or subcode, jointly with GAP-19's subcode design), or pin the strings in IB-13? | RP-20, IB-13 | network + portal teams |
+| OQ-8 | The network-state document's `effective_from` is honored by portals (fleet-coordinated cutover) but ignored by the worker (IB-40): during the window the worker may already reshuffle chunks that portals still route to under the previous assignment. Should WP-1 delay application until the effective time? | WP-1, IB-40 | network/scheduler team |

--- a/spec/03-data-model.md
+++ b/spec/03-data-model.md
@@ -1,0 +1,176 @@
+# 03 — Data model
+
+Home doc for `DEF`. Bands: DEF-1..9 primitives and entities · DEF-10..19 state ·
+DEF-20..29 metering and actors · DEF-30..39 inputs and operations.
+
+## Primitives and entities
+
+**DEF-1 — Dataset.** An opaque string naming a logical data collection (e.g. a chain's
+history). Equality is exact string equality; the worker never interprets dataset names.
+
+**DEF-2 — Chunk.** The unit of data placement: an immutable set of named **table files**
+covering a contiguous **block range** `[first, last]` (`first, last ∈ ℕ`,
+`first ≤ last`) within one dataset. A chunk's file list, byte content, and range are
+fixed at creation; the worker never mutates chunk content.
+
+**DEF-3 — Chunk id.** An opaque string identifying a chunk within its dataset. Equality
+is exact string equality. Two distinct chunks MAY cover the identical block range
+(**suffix forks**, ADR-4); ids are the only identity. The id is *never* a source of
+truth for the chunk's range on the read path (ADR-4); the sole sanctioned parse of an id
+into a range is the metering chip computation (DEF-24 — a known architectural debt,
+GAP-13).
+
+**DEF-4 — Chunk ref.** The pair ⟨dataset, chunk id⟩ — the global key of a chunk. All
+state sets (DEF-10) contain chunk refs. The worker orders chunk refs lexicographically
+by ⟨dataset, chunk id⟩; this ordering defines the availability map (DEF-13).
+
+**DEF-5 — Assignment.** A network-published document: an identifier (opaque, ADR-16),
+per-dataset chunk lists (each chunk with its file names, download addresses, and
+declared size), a worker roster with per-worker chunk subsets and an assessed **worker
+state** (ok / unreliable / deprecated version / unsupported version), and per-worker
+encrypted download credentials. The worker's slice: the chunk refs listed for it.
+
+**DEF-6 — Chunk store.** The worker's persistent store of chunk data. Its layout
+invariants (no partial range overlaps within a dataset; identical-range forks legal) are
+INV-3; the store is the single source of truth for what is available (INV-2) — there is
+no separate manifest or journal.
+
+**DEF-7 — Log record.** The durable evidence of one admitted query: ⟨query id (unique,
+INV-5), receipt timestamp, client identity, the full original query, outcome (success
+summary: uncompressed size, content hash, `last_block` — or the error), execution
+timings, worker version⟩.
+
+**DEF-8 — Log store.** The persistent, bounded-retention sequence of log records,
+ordered by ⟨timestamp, query id⟩ (the **log cursor** order, DEF-14).
+
+## State
+
+**DEF-10 — Core state tuple.** The worker's entire mutable model state:
+
+```
+S = ⟨ A, D, N, X, L, Q ⟩
+A : set of chunk refs   — available: committed, queryable
+D : set of chunk refs   — downloading: fetch in flight
+N : set of chunk refs   — desired: the applied assignment's slice for this worker
+X : assignment | ⊥      — the applied assignment document (⊥ before the first)
+L : chunk ref ⇀ ℕ⁺      — pins: per-chunk count of executing queries
+Q : sequence of log records (bounded by retention, WP-17)
+```
+
+Derived values:
+
+- `P = N \ A \ D` — **pending**: assigned, not yet held or in flight.
+- `U : N → bool` — the **unavailability map** (DEF-13).
+- `dom(L) ⊆ A` — only available chunks can be pinned (INV-4).
+
+Well-formedness is defined by the structural invariants INV-1..5 (single source of
+truth: [07-invariants.md](07-invariants.md)).
+
+**DEF-11 — Committed chunk.** A chunk whose entire file set has been atomically
+published into the chunk store (WP-12). Commitment is per-chunk; there is no
+per-assignment commit (CN-1).
+
+**DEF-12 — Pin.** A lease on an available chunk taken for the duration of one query's
+execution. While `L(c) > 0`, chunk `c` is exempt from eviction (INV-12). Pins are not
+persistent; recovery resets `L = ∅`.
+
+**DEF-13 — Unavailability map.** A bit sequence with one bit per desired chunk in
+chunk-ref order (DEF-4), bit = 1 iff the chunk is not available. Reported in the
+heartbeat (RP-21). ⚠ Whether this order matches the scheduler's interpretation for
+suffix forks is OQ-1.
+
+**DEF-14 — Log cursor.** The pair ⟨timestamp, query id⟩ under lexicographic order; the
+resumption token of log delivery (RP-22). Records are served only once their timestamp
+is at least P-LOGS-LAG old, because record order and timestamp order may disagree near
+the head (ADR-13).
+
+**DEF-15 — Snapshot (unit of read isolation).** One pinned chunk. A query observes
+exactly one committed chunk version for its whole execution; there is no multi-chunk or
+store-wide snapshot (NG1, CN-2).
+
+## Metering and actors
+
+**DEF-20 — Portal.** A network client that sends queries. Identified by its transport
+peer identity, which is also its signature identity (RP-2).
+
+**DEF-21 — Operator and cluster.** The on-chain accountable party. Each portal maps to
+one operator; all portals of one operator's cluster share that operator's CU budget.
+
+**DEF-22 — Epoch.** The network's metering period, read from the chain registry. CU
+allocations are per operator per epoch; allocations refresh when the observed epoch
+increases.
+
+**DEF-23 — Compute unit (CU) and bucket.** The admission currency. Each operator has a
+token bucket: capacity P-CU-BURST tokens, refill rate `allocation / epoch length`.
+Admission spends 1.0 token; execution may refund a fraction (DEF-24).
+
+**DEF-24 — Chip.** The fraction of a chunk a query actually covered:
+`chip = clamp(active range length / chunk range length, 0..1)`, computed from the
+queried range intersected with the chunk's range. Net cost of an admitted query =
+`chip`; the refund `1 − chip` is applied after execution regardless of outcome, except
+overload rejections, which keep the full unit (ADR-6).
+
+**DEF-25 — Admission.** The bar a query passes to become billable: signature and
+timestamp verification, envelope validation, capacity reservation, CU spend — in that
+order (RP-1, ADR-7). Everything past admission is logged (INV-32); nothing before it is.
+
+**DEF-26 — Delivery.** The pair ⟨wire response, log record⟩ produced from a single
+execution outcome (ADR-8). A **downgrade** replaces a success that cannot be shipped
+(oversized, unsignable) with the taxonomy's `server_error` in *both* halves (INV-23).
+
+## Inputs and operations
+
+**DEF-30 — Input events.** Everything that can change model state:
+
+| Event | Content | Delivery | Meaning |
+|---|---|---|---|
+| assignment-published | network-state document naming a new assignment id | polled every P-ASSIGN-POLL; at-least-once; last-writer-wins | triggers fetch + WP-10 |
+| chunk-fetched | one chunk's complete file set | pull from data origin; retried per WP-13 | enables WP-12 |
+| query | signed query message | request/response; exactly-once per stream | RP path; pins, meters, appends log |
+| logs-request | cursor | request/response | RP-22 read |
+| status-request | — | request/response | RP-21 read |
+| epoch-tick | epoch number + allocations | polled every P-EPOCH-POLL | refreshes DEF-23 buckets |
+| schema-refresh | schema manifest | polled every P-SCHEMA-REFRESH | updates dynamic-engine registry |
+| clock-tick | time | — | drives WP-17 log pruning, bucket refill |
+| process-crash / restart | — | — | WP-15 recovery |
+
+**DEF-31 — Transition summary.** Semantics live in [04-mutations.md](04-mutations.md):
+
+| Transition | One line |
+|---|---|
+| WP-10 apply-assignment | replace X and N wholesale; recompute P; A untouched |
+| WP-11 fetch-start | move one pending chunk into D, bounded by P-DL-CONC |
+| WP-12 commit | downloaded chunk becomes atomically available: D → A |
+| WP-13 abort | failed/cancelled fetch leaves D; re-pends if still desired |
+| WP-14 evict | unassigned, unpinned chunk leaves A and the store |
+| WP-15 recover | restart: adopt committed chunks, sweep residue, forget the assignment |
+| WP-16 log-append | admitted query appends exactly one record to Q |
+| WP-17 log-prune | records older than P-LOGS-RETENTION leave Q |
+
+**DEF-32 — Worker-state policy.** The assignment's per-worker assessed state maps to an
+operational posture:
+
+| Assessed state | Posture |
+|---|---|
+| ok | full service |
+| unreliable | full service; alarm level raised (OB-12) |
+| deprecated version | full service; upgrade alarm |
+| unsupported version | alarm; service expectations network-defined (explicitly unspecified here) |
+| absent from roster | previous assignment stays in force; alarm (FM-12) |
+
+## Terminology cross-reference
+
+| Codebase term | Spec term |
+|---|---|
+| `desired` / `available` / `downloading` / `to_download` | N / A / D / P (DEF-10) |
+| `ChunkRef` | chunk ref (DEF-4) |
+| `DatasetsIndex` | applied assignment X (DEF-10) |
+| chunk guard / `locks` | pin (DEF-12) |
+| `missing_chunks` bitstring | unavailability map (DEF-13) |
+| `Heartbeat` / `WorkerStatus` message | status report (RP-21) |
+| admission bar / `AdmittedQuery` | admission (DEF-25) |
+| `build_delivery` / `Logged` | delivery (DEF-26) |
+| `allocation_chip` | chip (DEF-24) |
+| workdir | chunk store (DEF-6) |
+| `logs.db` | log store (DEF-8) |
+| temp-prefixed directory | transient residue (RS-6) |

--- a/spec/04-mutations.md
+++ b/spec/04-mutations.md
@@ -1,0 +1,133 @@
+# 04 — Mutations
+
+Home doc for `WP`. Bands: WP-1..9 intake and loop rules · WP-10..17 transition catalog ·
+WP-20..29 commit, errors, restart continuity.
+
+## The reconciliation loop
+
+Conceptually (normative pseudocode; scheduling between steps is free; the transitions
+are summarized in DEF-31):
+
+```
+loop:
+    wait for: assignment applied | fetch finished | pin released | shutdown
+    cancel fetches no longer desired                    # WP-13
+    for c in A where c ∉ N and L(c) = 0: evict(c)       # WP-14
+    while |D| < P-DL-CONC and P ≠ ∅:
+        c := next_pending()                             # WP-3 fairness
+        fetch(c)                                        # WP-11
+```
+
+**WP-1 — Assignment intake.** [MUST] The worker polls the network-state document every
+P-ASSIGN-POLL and, on a changed assignment id, fetches the assignment document (DEF-5,
+bounded by P-ASSIGN-FETCH-TIMEOUT) and applies it (WP-10). An unchanged id is a no-op.
+Fetch/poll failures retry with jittered exponential backoff from P-ASSIGN-RETRY-BASE
+capped at P-ASSIGN-RETRY-MAX; retries of one stage MUST NOT starve intake of newer
+assignments indefinitely. [Non-starvation is intent, currently violated: GAP-9.]
+⚠ Application timing relative to the document's declared effective time is OQ-8
+(applied immediately today).
+
+**WP-2 — Intake validation.** [MUST — intent, currently violated: GAP-4] Before
+application, the assignment document is structurally validated and its decompressed size
+bounded by P-ASSIGN-SIZE-MAX ⚠ (ADR-18). A document that fails validation, lacks an
+entry for this worker, or fails credential decryption is rejected whole: the applied
+assignment X, N, and the reported assignment id remain those of the last good
+assignment, and an alarm is raised (FM-12). Per-item tolerance: an individual malformed
+download address or credential entry MUST degrade to per-chunk fetch failure, never
+process failure (FM-11).
+
+**WP-3 — Fetch fairness.** [SHOULD] `next_pending()` picks a chunk from the dataset with
+the fewest pending chunks (smallest-backlog-first), so a small or lagging dataset
+completes ahead of a bulk backfill. Within a dataset, order is unspecified (02
+§explicitly-unspecified).
+
+**WP-4 — Single applier.** [MUST] At most one assignment application executes at a time;
+an application in progress is never interrupted by a newer arrival (ADR-16). Arrivals
+queue; the queue MAY coalesce to the newest.
+
+## Transition catalog
+
+**WP-10 — apply-assignment.**
+*Pre:* a fetched assignment document that passed WP-2; no other application in progress.
+*Post:* `X′ = new document`, `N′ = its slice for this worker`, `P′ = N′ \ A \ D`.
+`A`, `D`, `L`, `Q` unchanged — application never deletes or interrupts anything by
+itself; deletions happen only via subsequent WP-14. Applying a document yielding
+`N′ = N` is a no-op apart from `X′`.
+
+**WP-11 — fetch-start.**
+*Pre:* `c ∈ P`, `|D| < P-DL-CONC`.
+*Post:* `D′ = D ∪ {c}` (so `c ∉ P′`). Fetch work happens outside the model state; only
+WP-12/13 conclude it.
+
+**WP-12 — commit.**
+*Pre:* `c ∈ D`; every file of `c` fully retrieved.
+*Post:* `c`'s file set is published into the chunk store by a single atomic namespace
+operation (CN-1); `A′ = A ∪ {c}`, `D′ = D \ {c}`. Visibility to queries begins at this
+transition and not before. If `c ∉ N` by commit time, the chunk is still committed and
+then evicted by a later WP-14 (commit does not consult N).
+
+**WP-13 — abort.**
+*Pre:* `c ∈ D`; the fetch failed, timed out (per-file bound P-DL-FILE-TIMEOUT, stall
+bound P-DL-STALL-TIMEOUT), or was cancelled (no longer desired).
+*Post:* `D′ = D \ {c}`; all partial data of `c` is transient residue (RS-6), never
+visible. If `c ∈ N′`, then `c ∈ P′` — failed fetches retry indefinitely while desired,
+under backoff from P-DL-BACKOFF-BASE capped at P-DL-BACKOFF-MAX. The backoff scope
+SHOULD be per-origin or per-chunk so one failing chunk does not throttle others.
+[Scope is intent, currently violated — the backoff is global: GAP-7.] Abort-path
+noise from transient-name collisions is a registered hazard (HZ-10).
+
+**WP-14 — evict.**
+*Pre:* `c ∈ A`, `c ∉ N`, `L(c) = 0`.
+*Post:* `A′ = A \ {c}`; the chunk leaves the store namespace atomically, then its bytes
+are reclaimed (RS-4 two-phase; interactions: RS-9). This is the **only** transition by which committed data
+leaves the store (INV-11). Eviction failure is a per-chunk degraded state with an alarm,
+not process failure. [Intent, currently violated — eviction failure panics: GAP-6.]
+
+**WP-15 — recover.**
+*Pre:* process start.
+*Post:* `A′ = { committed chunks found in the store }`, `D′ = ∅`, `L′ = ∅`, `X′ = ⊥`,
+`N′ = A′` (nothing is deleted or fetched until the first assignment applies), `Q′ = `
+the durable log records. All transient residue is swept (RS-6). Recovery MUST tolerate
+unrecognized entries in the store (skip-and-alarm, CN-10); a malformed *layout* of
+recognized chunks is a startup failure (INV-3). ⚠ Skip-vs-fail granularity for corrupt
+individual chunks is GAP-20 / ADR-18.
+
+**WP-16 — log-append.**
+*Pre:* a query passed admission (DEF-25) and its delivery (DEF-26) was built.
+*Post:* `Q′ = Q ⧺ [record]`. Exactly one record per admitted query (INV-32); the record
+and the wire response derive from the same outcome (INV-23). Append failure is alarmed;
+it never affects the response. Ordering: the response MAY be sent before the record is
+durable (ADR-13 — accepted crash window).
+
+**WP-17 — log-prune.**
+*Pre:* records with timestamp older than `now − P-LOGS-RETENTION` exist.
+*Post:* those records leave Q and their space is reclaimable (RS-7). Pruning is
+oblivious to delivery: an undelivered record past retention is lost (accepted, cited by
+RS-7); collectors must poll within the retention window.
+
+## Commit, errors, restart
+
+**WP-20 — Commit point and no-partial-visibility.** [MUST] The commit point of a chunk
+is WP-12's single atomic publish. No query, status report, or metric may ever observe a
+chunk in a state between "absent" and "fully committed". The same applies in reverse to
+eviction.
+
+**WP-21 — Idempotency under redelivery.** [MUST] Re-applying the currently applied
+assignment is a no-op. Re-fetching an already available chunk is never scheduled
+(`P = N \ A \ D` guarantees it); a commit colliding with an existing committed chunk of
+the same ref MUST NOT corrupt the existing chunk — the incumbent wins and the incoming
+copy is discarded as residue. [Incumbent-wins is intent; today the collision wedges into
+an eternal retry: GAP-20.]
+
+**WP-22 — Error classification.** [MUST] Mutation-path errors are **transient**
+(retried under backoff: fetch failures, origin unavailability, assignment fetch
+failures) or **integrity** (alarmed, quarantined, never silently retried forever:
+layout violations, commit collisions, eviction failures). A transient error that
+persists beyond P-STALL-MAX becomes an alarm (LIV-9) — retry forever, but never
+silently. No input content may terminate the process (FM-1).
+
+**WP-23 — Restart continuity.** [MUST] After WP-15, the worker resumes from exactly the
+recovered committed state: previously committed chunks serve queries immediately;
+nothing is evicted until an assignment applies (WP-15's `N′ = A′`); the first applied
+assignment then drives normal reconciliation. Recovery is idempotent (CN-5) — crashing
+during recovery and recovering again yields the same state.

--- a/spec/05-queries.md
+++ b/spec/05-queries.md
@@ -1,0 +1,165 @@
+# 05 — Queries
+
+Home doc for `RP`. Bands: RP-1..9 admission · RP-10..19 result contract ·
+RP-20..29 status and log reads, error taxonomy.
+
+## Operations
+
+| Operation | Kind | Contract |
+|---|---|---|
+| chunk query | read + meter + log | RP-1..15 |
+| status read | watermark read | RP-21 |
+| logs read | cursor read | RP-22 |
+| local status / metrics read | operator read | RP-23, OB |
+
+## Admission
+
+**RP-1 — Admission sequence.** [MUST] A query passes, in order: (1) authentication —
+signature verifies against the sender's identity and binds this worker's identity;
+(2) freshness — timestamp within P-TS-WINDOW of the worker clock (clock discipline:
+CN-8); (3) envelope
+validation — recognized engine and output-format selectors, and a legal
+engine/format pairing; (4) capacity — a queue slot is reserved (else `server_overloaded`
+with a P-RETRY-HINT); (5) metering — 1.0 CU is spent from the sending portal's (DEF-20) operator bucket
+(DEF-21) — else `too_many_requests`, with a retry hint iff the operator has an
+allocation.
+Order is load-bearing: a spent CU always corresponds to an enqueued query (ADR-7).
+Failures at steps 1–5 are **pre-admission**: no CU, no log record.
+
+**RP-2 — Authentication scope.** [MUST] The signature covers the query id, this worker's
+identity, the timestamp, dataset, query body, chunk id, block range, and the
+engine/format selectors — a signed query cannot be replayed at another worker nor have
+its semantics altered in transit. ⚠ Replay of the identical query at the same worker
+within P-TS-WINDOW is currently not prevented (GAP-12). Compression choice is outside
+the signature (accepted: it affects encoding, not semantics — but see OQ-5).
+
+**RP-3 — Post-admission validation.** [MUST] Remaining envelope checks (compression
+selector, presence of the block range) happen after admission: failures cost the full CU
+and are logged (ADR-7 draws the billable line at admission, and the test-pinned policy
+is that malformed-but-admitted queries pay).
+
+**RP-4 — Concurrency and overload.** [MUST] At most P-Q-PAR queries execute
+concurrently [enforcement is intent, currently violated: GAP-1]; the intake queue holds
+P-Q-QUEUE per protocol surface with P-Q-STREAMS concurrent message handlers; excess
+yields `server_overloaded` + P-RETRY-HINT. An overload rejection after admission keeps
+the CU (ADR-6). Rejection responses themselves are bounded by P-REJECT-CONC concurrent
+signing tasks; beyond that the connection is dropped unanswered (ADR-9).
+
+**RP-5 — Timeout and cancellation.** Every admitted query SHOULD complete or fail
+within P-Q-DEADLINE ⚠ (OQ-6), and execution SHOULD be cancelled when the requester
+disconnects. [Both are intent, currently violated: no deadline, no cancellation —
+GAP-8.] Response write timeouts are the transport's (IB-2).
+
+## Result contract
+
+**RP-10 — Scope.** [MUST] A query addresses exactly one chunk (DEF-2) of one dataset
+(DEF-1) (NG1, ADR-12). The chunk must be available at execution start; the effective range is the
+query's block range clipped to the chunk's actual content. The worker MUST NOT reject a
+range disjoint from the chunk — it returns an empty result (RP-11 rules apply).
+
+**RP-11 — Coverage and progress.** [MUST] A successful result covers a gap-free prefix
+of the effective range: `covered = [range.begin, last_block]`. Rules:
+- Every block in `covered` that the query selects is emitted completely (no partial
+  blocks — truncation granularity is the whole block).
+- `last_block ≤ range.end` always; `last_block` = the highest block actually evaluated.
+- Boundary emission: when at least one block is evaluated, the result includes a record
+  for the first and last evaluated block — header-only when the query selects nothing
+  from them — so the coverage cursor is recoverable from the data alone; portal-side
+  client resumption load-bears on this. [MUST — intent; provided today by the legacy
+  engine's weight-0 boundary pinning, dynamic-engine conformance unverified: GAP-32.]
+- Empty result: a range that evaluates zero blocks (disjoint from the chunk's content,
+  RP-10) yields empty data with `last_block = range.end`; an evaluated range never
+  yields zero records (boundary emission above).
+- Progress guarantee: a successful response always advances the client — either
+  `last_block ≥ range.begin` (at least one block evaluated) or the result is the
+  empty-selection case covering everything.
+- Coverage is recoverable by the client from `last_block` alone, even with zero emitted
+  rows.
+
+**RP-12 — Emission order.** [MUST] Row-oriented output emits blocks in ascending block
+order, one record per line; columnar output emits per-table streams whose row order
+within a table is ascending by block. Determinism: byte-identical results for identical
+⟨query, chunk content, format⟩ modulo the declared free variables (13 §free variables).
+
+**RP-13 — Truncation is normal.** [MUST] The engine stops early when the result-size
+budget P-RESP-BUDGET is reached, keeping at least one whole block. Early stop is
+signalled *only* through `last_block < range.end` — there is no error, no flag; clients
+MUST treat it as success and resume. The client recovery algorithm (normative — this is
+a conformance driver):
+
+```
+next := range.begin
+while next ≤ range.end:
+    r := query(chunk, [next, range.end])
+    if r is error: handle per taxonomy (RP-20); retry or reroute
+    else: consume(r.data); next := r.last_block + 1
+```
+
+**RP-14 — Size bounds.** [MUST] Uncompressed result data never exceeds P-RESP-MAX; the
+encoded response message never exceeds the transport's response ceiling (IB-2). A result
+that would exceed either is **downgraded** to `server_error` in both response and log
+(DEF-26). A single block whose emission alone exceeds the budget is such a downgrade,
+not an infinite truncation loop. [The two oversize paths currently emit divergent
+`server_error` strings: GAP-31.]
+
+**RP-15 — Result integrity.** [MUST] The response is signed over ⟨query id, content
+hash, `last_block`⟩; the log record carries the uncompressed content hash and size
+(OQ-5 tracks the compressed-vs-uncompressed discrepancy with portal-side records).
+Error responses are signed over ⟨query id, error class⟩ — the class is authenticated,
+the message text is not (IB-13).
+
+## Status and log reads, errors
+
+**RP-20 — Error taxonomy.** [MUST] The closed set of query outcomes. No other outcome
+class exists; message strings are advisory and unstable; classes are stable surface.
+
+| Class | Trigger | CU | Logged | Retryable |
+|---|---|---|---|---|
+| `bad_request` | authentication, freshness, envelope, unparseable/uncompilable query, unknown table/column | pre-admission: 0 · post: 1·chip | pre: no · post: yes | no (fix and resend; freshness: yes with new timestamp) |
+| `not_found` | chunk not available (never assigned, not yet fetched, or evicted) | full refundable chip path | yes | yes — reroute, or retry after the availability map shows the chunk |
+| `too_many_requests` | operator bucket empty or no allocation | 0 | no | yes after hint; without allocation, only after on-chain change |
+| `server_overloaded` | capacity exhausted (queue or concurrency) | pre-admission: 0 · post-admission: 1 (ADR-6) | post only | yes after P-RETRY-HINT |
+| `server_error` | execution failure, downgrade (RP-14), signing failure, internal fault | 1·chip | yes | unknown; safe to retry (idempotent reads) |
+| *(no response)* | undecodable request, reject fan-out exhausted, transport limits | 0 | no | yes (treat as transient) |
+
+Errors never carry result data (INV-20). A `not_found` does not distinguish its three
+causes (GAP-19 tracks adding machine-readable subcodes); the availability map (RP-21) is
+the sanctioned disambiguator for status consumers (the scheduler) — query clients
+reroute on `not_found` without reading it.
+
+**Anchor-mismatch verdict.** [MUST — intent, currently violated: GAP-30] A query whose
+body carries a continuation anchor (the expected parent hash of the first selected
+block) that the chunk's data contradicts MUST fail with a machine-distinguishable
+verdict carrying the canonical block reference at the anchor height; portals convert it
+into their fork-recovery conflict response. Today the verdict exists only as the legacy
+engine's `server_error` message text; until a stable surface lands (OQ-7), the exact
+strings are a de-facto frozen contract (IB-13).
+
+**RP-21 — Status read.** [MUST] On request, the worker returns its status report:
+version, applied assignment id (empty until the first application), the unavailability
+map (DEF-13), stored bytes, current epoch (absent until first observed). Honesty and
+freshness: all fields derive from one coherent state snapshot (INV-30) no older than
+P-HB-STALENESS [freshness intent, currently violated when store walks are slow:
+GAP-15]. The assignment id only ever advances to ids of successfully applied
+assignments; a failed application never changes it (WP-2). Status is currently unsigned
+(OQ-4).
+
+**RP-22 — Logs read.** [MUST] A logs request carries a cursor (DEF-14). The response
+returns records strictly after the cursor, in cursor order, whose timestamps are at
+least P-LOGS-LAG old, truncated to P-LOGS-RESP-MAX bytes with a has-more flag.
+Guarantees: at-least-once delivery within the retention window; no gaps and no
+reordering for a client that resumes from the last received cursor; records older than
+P-LOGS-RETENTION MAY be gone regardless of delivery (WP-17). Requests beyond the
+read-queue bound P-LOGS-QUEUE are dropped unanswered.
+
+**RP-23 — Local reads.** [MUST] The operator surface exposes: chunk-count state, the
+worker's network identity, and the full metrics inventory (OB). These are
+operator-facing and unauthenticated by design; they never expose query contents.
+
+**RP-24 — Read-side resource bounds.** [MUST] Result construction memory is bounded per
+query by a constant multiple of P-RESP-MAX ⚠ (P-MEM-CEIL tracks the process-wide
+target); a slow or dead reader costs at most the transport write timeout (IB-2), after
+which the response is abandoned (the implied minimum reader rate for large results is
+HZ-14). Log reads are bounded by P-LOGS-RESP-MAX per response. Status reads MUST be
+bounded by P-STATUS-CONC concurrent handlers [intent, currently violated — unbounded
+task spawn: GAP-29].

--- a/spec/06-consistency-durability.md
+++ b/spec/06-consistency-durability.md
@@ -1,0 +1,76 @@
+# 06 — Consistency and durability
+
+Home doc for `CN`. Band: CN-1..10.
+
+**CN-1 — Atomic per-chunk visibility.** [MUST] The unit of atomic visibility is one
+chunk (DEF-11). A chunk transitions absent → fully-available in a single indivisible
+namespace operation (WP-12, WP-20), and available → absent likewise (WP-14). No reader —
+query, status read, recovery scan, or metric — ever observes a partial chunk. There is
+no cross-chunk atomicity: a half-applied assignment is a normal state, reported
+honestly via the unavailability map (DEF-13).
+
+**CN-2 — Read isolation.** [MUST] A query's snapshot is its single pinned chunk
+(DEF-15). From pin acquisition to release, the chunk's content is immutable and its
+storage is not reclaimed, regardless of concurrent assignment changes or evictions
+(INV-12). Lookup and pin acquisition are atomic with respect to eviction: a query
+either fails `not_found` or holds a valid pin — never a dangling path (CT-3 races
+this).
+
+**CN-3 — Recovery contract.** [MUST] Recovered state ≡ some committed state, in every
+field: `A` after WP-15 is exactly the set of chunks whose WP-12 commit completed and
+whose WP-14 eviction did not, each with its full committed file set; derived state
+(pending set, unavailability map, metrics gauges) is recomputed from that, never
+restored from any cache. An eviction whose namespace removal completed stays evicted;
+one that did not stays available (re-eviction follows from the next assignment
+application — an eviction may thus *un-happen* across a crash, which is accepted and
+cited here as the CN-3 re-adoption caveat, bounded by WP-15's `N′ = A′` rule).
+
+**CN-4 — Durability tiers.** [MUST]
+- **Process crash (kill, panic, out-of-memory): zero loss.** Every committed chunk and
+  every durable log record survives fully intact; transient residue is swept (RS-6).
+- **System crash (power loss, kernel fault): bounded suffix loss, well-formed.** Chunks
+  committed within the unsynchronized window MAY be lost *as wholes*; what survives
+  MUST be well-formed (INV-3) and content-intact. [Content intactness after system
+  crash is intent, currently violated — an unsynchronized commit can survive the crash
+  with truncated content and still be adopted as available: GAP-5.] Log records are
+  durable at append (CN-6) with at most the in-flight record lost (ADR-13).
+
+**CN-5 — Recovery idempotence.** [MUST] Recovery is a pure function of the store's
+durable contents: crashing at any point during WP-15 and recovering again yields the
+identical adopted state and sweeps the identical residue. Recovery performs no
+destructive act on committed data.
+
+**CN-6 — Log-store durability.** [MUST] A log record (DEF-7), once appended (WP-16),
+survives
+process and system crash. The accepted exception (ADR-13): the response for a query may
+be sent before its record is durable, so a crash in that window loses at most the
+records of responses already sent within it — an accountability loss, never a
+correctness loss for clients.
+
+**CN-7 — Maintenance transparency.** [MUST] Background work — residue sweeps, space
+reclamation after eviction, log pruning past retention, store-size accounting — never
+changes logical state: the available set, pinned chunks' content, unexpired log
+records, and every response are bit-identical with maintenance on or off (metamorphic
+test, CT-1).
+
+**CN-8 — Clock independence.** [MUST] Safety never depends on wall-clock monotonicity
+or accuracy: a clock jump may delay or hasten freshness-gated behavior (admission
+freshness, log lag, pruning) but MUST NOT corrupt state, violate INV-*, or terminate
+the process. Backward jumps MUST NOT resurrect pruned records or double-refill metering
+buckets beyond P-CU-BURST.
+
+**CN-9 — Single writer.** [MUST] One process owns a store at a time. A process
+discovering a store stamped with a different network identity MUST refuse to serve —
+before mutating anything, including residue sweeps. [Ordering is intent, currently
+violated — the sweep runs before the identity check: GAP-16.] Same-identity concurrent
+access is explicitly unspecified (02) and unenforced today (ADR-15; GAP-16 tracks the
+hardening decision).
+
+**CN-10 — Format compatibility gate.** [MUST] On startup the worker recognizes its own
+store formats. Unrecognized *foreign* entries (unknown directories, stray files) are
+tolerated: skipped with an alarm, never deleted, never adopted. Recognized-but-invalid
+layout (INV-3 violations among adopted chunks) fails startup rather than serving
+inconsistent data. A log-store schema change is applied by migration-on-open, leaving
+prior data readable or explicitly migrated — never silently ignored. ⚠ Today's
+schema-bump-by-table-rename leaves orphaned prior-generation data unpruned forever;
+tracked via GAP-10's register entry.

--- a/spec/07-invariants.md
+++ b/spec/07-invariants.md
@@ -1,0 +1,234 @@
+# 07 — Invariants
+
+Home doc for `INV`. Bands: 1..9 structural · 10..19 transition legality ·
+20..29 response semantics · 30..34 reporting · 35..39 isolation ·
+40..49 durability/recovery. Scope tags per README conventions.
+
+## Structural
+
+**INV-1 — Set partition.** [state]
+`A ∩ D = ∅`, and the pending set is exactly `P = N \ A \ D` at every observable point.
+A chunk is in at most one of {available, downloading}; nothing is fetched that is
+already held or in flight.
+*Why:* prevents double downloads, phantom availability, and lost chunks between sets.
+*Check:* CT-1 — model-conformance assertion after every transition; state exposed via
+OB-1 gauges and the status read.
+
+**INV-2 — Store correspondence.** [state]
+`A` = exactly the set of committed chunks physically present in the chunk store. No
+manifest exists to diverge from reality; a chunk is available iff its committed form is
+present.
+*Why:* the store is self-describing; any cached availability that outlives the data
+serves queries from nothing.
+*Check:* CT-1/CT-2 — after arbitrary transition + crash sequences, compare the status
+read's implied A against a direct store scan.
+
+**INV-3 — Layout well-formedness.** [state]
+Within a dataset, the block ranges of any two distinct committed chunks are either
+disjoint or identical (suffix forks, ADR-4). Partial overlaps never exist among adopted
+chunks.
+*Why:* overlapping ranges make coverage (RP-11) ambiguous and progress unsound.
+*Check:* CT-2/CT-4 — recovery over corpus stores with crafted overlaps must refuse
+adoption; property tests never produce an overlapping store.
+
+**INV-4 — Pin validity.** [state]
+`dom(L) ⊆ A` and every pin count is positive: only available chunks are pinned, and a
+pin outlives neither its query nor its chunk's availability entry being consumed by
+eviction (which INV-12 forbids while pinned).
+*Why:* a pin on a nonexistent chunk is a dangling read; an unpinned executing query is
+an eviction race.
+*Check:* CT-1/CT-3 — assertion in the reference model; concurrency swarm evicting under
+load.
+
+**INV-5 — Log-store well-formedness.** [state]
+Log records have unique query ids; the sequence is totally ordered by the cursor
+⟨timestamp, query id⟩; every record's timestamp is within the retention window or the
+record is eligible for pruning.
+*Why:* duplicate ids break at-least-once delivery accounting and billing evidence.
+*Check:* CT-1/CT-7 — structural validator over pulled logs; soak with replayed ids.
+
+## Transition legality
+
+**INV-10 — Frame condition.** [transition]
+Model state changes only via the cataloged transitions WP-10..17, each triggered by its
+input event (DEF-30). Absent inputs, state is constant: no background process changes
+`A`, `N`, `D`, `L`, or unexpired `Q`.
+*Why:* catches whole classes of bugs — spontaneous eviction, maintenance mutating
+logical state, phantom downloads.
+*Check:* CT-1 — quiescence: with inputs stopped, two spaced state observations are
+identical (modulo log pruning at the retention edge).
+
+**INV-11 — Destructive ops are explicit.** [transition]
+Committed data leaves the store only via WP-14 (evict) and log records only via WP-17
+(prune). No other path — recovery, maintenance, error handling, incoming downloads —
+deletes committed data.
+*Why:* data loss must be enumerable; "cleanup" code paths are where stores lose data.
+*Check:* CT-2 — kill-point matrix asserts recovered stores never lack a chunk that was
+committed and never evicted; ledger comparison (HC-2).
+
+**INV-12 — Eviction legality.** [transition]
+WP-14 fires only for chunks that are simultaneously: committed (`c ∈ A`), unassigned
+(`c ∉ N`), and unpinned (`L(c) = 0`). Mass eviction is additionally bounded by REQ-25.
+*Why:* protects executing queries and assigned data from any reconciliation bug.
+*Check:* CT-1/CT-3 — model conformance; swarm test querying chunks while shrinking
+assignments.
+
+**INV-13 — Commit provenance.** [transition]
+A chunk committed by WP-12 contains exactly the files the assignment names for it, with
+exactly the bytes the data origin served for those files.
+*Why:* provenance fidelity — the store must be a faithful replica; silent truncation or
+substitution poisons every future query.
+*Check:* CT-1 — HC-2's origin ledger is the oracle: compare committed files against
+served bytes.
+
+**INV-14 — Application atomicity.** [transition]
+WP-10 replaces `X` and `N` wholesale in one transition; no observation sees a mix of
+two assignments' desired sets, and `A`/`D`/`L` are untouched by application itself.
+*Why:* torn desired-sets produce spurious eviction/fetch churn and incoherent status.
+*Check:* CT-3 — status reads race assignment flips; each observed N must equal some
+applied assignment's slice.
+
+**INV-15 — Metering conservation.** [transition]
+Per operator: net CU spend = Σ chips of its admitted queries, +1 per post-admission
+overload rejection (ADR-6), +0 per pre-admission rejection. A CU is spent iff a query
+was admitted (ADR-7); refunds never exceed the spend they offset; bucket level never
+exceeds P-CU-BURST.
+*Why:* the economic contract; over-charging steals from operators, under-charging
+invites overload.
+*Check:* CT-1 — CU-conservation property test against the reference bucket model
+(exists today as unit tests; promote to property form).
+
+## Response semantics
+
+**INV-20 — Response soundness.** [response]
+Every admitted query yields exactly one response, drawn from the closed taxonomy
+(RP-20), signed. Error responses carry no result data. No admitted query yields zero
+or two responses (unanswered drops are pre-admission only, RP-20's last row).
+*Why:* portals must be able to treat the response stream as authoritative.
+*Check:* CT-5 — interface conformance: response accounting per injected query.
+
+**INV-21 — Result provenance.** [response]
+Successful result data derives exclusively from the pinned chunk's committed content
+via the declared evaluation function — never from partial downloads, evicted data,
+another chunk, or another query's buffers.
+*Why:* cross-chunk or torn reads are silent data corruption at the consumer.
+*Check:* CT-1/CT-3 — HC-2 ledger + reference evaluation comparison, raced against
+churn.
+
+**INV-22 — Coverage honesty.** [response]
+`last_block` obeys RP-11 exactly: never exceeds the requested end; equals the truncation
+point on early stop; equals range end on empty selection; resumption per RP-13 loses
+nothing and duplicates nothing.
+*Why:* the entire incremental-consumption protocol rests on this one number.
+*Check:* CT-1 — resumption-equivalence property test (chunked reads ≡ whole read).
+
+**INV-23 — Delivery-log agreement.** [response]
+The wire response and the log record of one query agree on the outcome class and
+content summary; a downgrade (RP-14) is a downgrade in both. No path produces a
+successful response with an error log or vice versa.
+*Why:* billing disputes are adjudicated from logs; divergence is unauditable.
+*Check:* CT-5 — compare pulled log records against received responses per query id.
+
+**INV-24 — Response size bound.** [response]
+No response's uncompressed data exceeds P-RESP-MAX; no encoded response exceeds the
+transport ceiling (IB-2); oversized results downgrade rather than truncate mid-block.
+*Why:* transport-level failures on oversize look like network faults and are
+undebuggable.
+*Check:* CT-4/CT-6 — boundary corpus at the budget edges.
+
+**INV-25 — Signature validity.** [response]
+Every response (success or error) verifies against the worker's network identity; the
+signed payload binds the query id (and for successes, content hash and `last_block`).
+*Why:* unforgeable provenance is the network's trust anchor for served data.
+*Check:* CT-5 — verify every response in every suite run.
+
+## Reporting
+
+**INV-30 — Status coherence.** [response]
+All fields of one status report derive from a single state snapshot: the unavailability
+map is computed against the same assignment whose id the report carries, and its length
+equals that assignment's chunk-list length. [Known-violated: GAP-11.]
+*Why:* a scheduler indexing the map by the wrong assignment misroutes the whole
+network's queries.
+*Check:* CT-3 — status reads raced against assignment application; length and id
+cross-check.
+
+**INV-31 — Metrics honesty.** [state]
+Every OB gauge equals its model quantity at observation (within one update interval):
+available/downloading/pending counts match the sets; the running-query gauge matches
+in-flight admitted queries; counters count what their names claim. [Known-violated: the
+running-query gauge reads ~0 — GAP-1.]
+*Why:* operators act on these numbers; a lying gauge converts incidents into mysteries.
+*Check:* CT-1/CT-6 — scraper cross-checks gauges against harness-known state
+(12 §lying-metrics rule).
+
+**INV-32 — Log completeness.** [transition]
+Exactly one log record per admitted query — including downgrades, post-admission
+errors, and overload keeps. No record for pre-admission rejections. [Known-violated at
+the margins: duplicate query ids and oversized records are silently dropped — GAP-12,
+GAP-14.]
+*Why:* the worker's revenue and the network's audit trail.
+*Check:* CT-5/CT-7 — per-query-id reconciliation of injected load vs pulled logs.
+
+## Isolation
+
+**INV-35 — Cross-client isolation.** [response]
+No query's response or log record is influenced by another client's concurrent
+activity, beyond shared-capacity rejections (RP-4) and metering of the *same*
+operator. One operator's exhausted bucket never affects another's admission.
+*Why:* multi-tenancy; noisy neighbors must cost capacity, not correctness.
+*Check:* CT-8 — noisy-neighbor swarm with per-client result verification.
+
+**INV-36 — Query fault containment.** [response]
+A failing query — engine panic, resource exhaustion inside evaluation, malformed body —
+yields a taxonomy error for that query only. It never terminates the process, poisons
+the engine pool, or fails other queries. (ADR-5.)
+*Why:* one bad query must never be a denial of service on the worker.
+*Check:* CT-4 — fault corpus including known panic triggers; process-liveness
+assertion.
+
+**INV-37 — Store/query non-interference.** [state]
+Reconciliation (downloads, evictions, sweeps) never blocks admitted queries beyond
+declared capacity limits, and queries never block reconciliation indefinitely (pins
+defer individual evictions, LIV-4 bounds the deferral).
+*Why:* the writer/reader/maintenance non-interference matrix collapses to this pair.
+*Check:* CT-3/CT-6 — throughput of each side measured while the other saturates.
+
+## Durability / recovery
+
+**INV-40 — Recovery soundness.** [recovery]
+Post-recovery `A` ⊆ committed-and-never-evicted chunks, with full committed content
+(CN-3, CN-4 tiers). No partial chunk, residue, or foreign entry is ever adopted.
+*Why:* recovery is the last line against corruption becoming service.
+*Check:* CT-2 — kill-point matrix, store diffed against the commit ledger.
+
+**INV-41 — Residue convergence.** [recovery]
+Transient residue (partial downloads, in-flight eviction remnants) is fully swept by
+the next recovery, and repeated crash/recover cycles do not accumulate residue or
+grow the store without bound (RS-6).
+*Why:* crash leftovers must not pin disk or wedge future commits.
+*Check:* CT-2/CT-7 — crash-loop soak; store size and entry census monotonicity.
+
+**INV-42 — Recovery idempotence.** [recovery]
+Two consecutive recoveries with no intervening inputs adopt identical state (CN-5);
+recovery itself never triggers WP-14 or WP-11.
+*Why:* recovery code that mutates is recovery code that destroys under repeated crash.
+*Check:* CT-2 — double-recovery comparison built into every kill-point run.
+
+**INV-43 — Log-record durability.** [recovery]
+Every log record appended before a crash is present after recovery (CN-6), modulo the
+ADR-13 in-flight window. Pruning respects retention even across restarts.
+*Why:* billing evidence must survive exactly as promised, no more (privacy) and no
+less (revenue).
+*Check:* CT-2 — logs pulled after crash compared to pre-crash acknowledged appends.
+
+## Reading the catalog in tests
+
+- Every CT-1 property run asserts INV-1..5 after each transition and INV-10..15 across
+  each transition, using the reference model (13) as oracle.
+- Every response in any suite passes the structural validators, which encode
+  INV-20..25.
+- CT-2 (kill-point matrix) owns INV-40..43; CT-3 (concurrency swarms) owns INV-14, 30,
+  37 and races INV-4/12/21.
+- CT-4/CT-9 (fault + fuzz corpus) own INV-36 and probe INV-3/24.
+- CT-5/CT-7/CT-8 own the accounting and isolation set: INV-15, 20, 23, 32, 35.

--- a/spec/08-liveness.md
+++ b/spec/08-liveness.md
@@ -1,0 +1,136 @@
+# 08 — Liveness
+
+Home doc for `LIV`. Band: LIV-1..14. Every property names its precondition, bound, and
+witness observable; a bound symbol marked ⚠ has no ratified target yet
+(ratification: ADR-19; values in [15-parameters.md](15-parameters.md)).
+
+## §0 — Environmental definitions
+
+Liveness claims hold only under these conditions; outside them the required behavior is
+09's (degrade + alarm, never silent hang):
+
+- **Healthy scheduler**: the network-state and assignment documents are reachable,
+  well-formed, and include this worker, with fetch latency within
+  P-ASSIGN-FETCH-TIMEOUT.
+- **Healthy origin**: every assigned chunk file downloads successfully within
+  P-DL-FILE-TIMEOUT without stalls beyond P-DL-STALL-TIMEOUT.
+- **Healthy registry**: epoch and allocation reads succeed within the polling cadence.
+- **Adequate resources**: free disk ≥ assigned-data size + RS-3's excess bound; memory
+  within P-MEM-CEIL ⚠; CPU not saturated by co-tenants.
+- **Quiescent**: no input events (DEF-30) arriving; in-flight work drained.
+
+## Properties
+
+**LIV-1 — Assignment convergence.**
+*Pre:* healthy scheduler + origin + adequate resources; an assignment is published and
+stable.
+*Bound:* P-ASSIGN-POLL + P-ASSIGN-FETCH-TIMEOUT + (pending-bytes / W-DL-RATE) +
+P-CONVERGE-SLACK ⚠.
+*Witness:* heartbeat reports the new assignment id with an all-zero unavailability map
+(OB-2/3).
+*Check:* CT-1, CT-6.
+
+**LIV-2 — Download progress.**
+*Pre:* `P ≠ ∅`, healthy origin, free capacity (`|D| <` P-DL-CONC).
+*Bound:* a WP-12 commit occurs within P-DL-FILE-TIMEOUT × W-CHUNK-FILES +
+P-DL-BACKOFF-MAX.
+*Witness:* the committed-chunks counter advances (OB-4).
+*Check:* CT-1.
+
+**LIV-3 — Query termination.**
+*Pre:* an admitted query.
+*Bound:* a signed response (or downgrade) within P-Q-DEADLINE ⚠. [Currently unbounded:
+GAP-8; OQ-6.]
+*Witness:* response observed by the driver; running-query gauge returns to baseline
+(OB-6).
+*Check:* CT-1, CT-4.
+
+**LIV-4 — Eviction convergence.**
+*Pre:* `c ∈ A`, `c ∉ N`, last pin released; process alive.
+*Bound:* store namespace removal within P-EVICT-BOUND ⚠ of the pin release — without
+requiring any further input event. [Currently violated: eviction waits for the next
+loop wake-up, potentially forever — GAP-6.]
+*Witness:* evicted-chunks counter advances (OB-4); stored-bytes gauge falls (OB-5).
+*Check:* CT-1, CT-3.
+
+**LIV-5 — Startup bound.**
+*Pre:* process start over a store of W-CHUNKS committed chunks; no corruption; on-chain
+registration confirmed (an unregistered worker polls the registry and serves nothing
+until listed — FM-54).
+*Bound:* accepting queries within P-START-ACCEPT ⚠; acceptance is decoupled from
+assignment intake (PF-4) — a dead scheduler delays convergence, never acceptance
+(degraded service: `not_found`/empty status until the first application).
+*Witness:* status endpoint responds; lifecycle phase timestamps (OB-10).
+*Check:* CT-2, CT-6.
+
+**LIV-6 — Status freshness.**
+*Pre:* process alive.
+*Bound:* every status report reflects state no older than P-HB-STALENESS. [At risk
+when store walks run long: GAP-15; probes HZ-1/7.]
+*Witness:* harness flips state and polls status until reflected; elapsed ≤ bound.
+*Check:* CT-3, CT-6.
+
+**LIV-7 — Log delivery progress.**
+*Pre:* collector polls at least every P-LOGS-RETENTION − P-LOGS-LAG with resumable
+cursors.
+*Bound:* every admitted query's record is delivered before pruning; each response page
+advances the cursor or sets has-more = false.
+*Witness:* per-query-id reconciliation (CT-5's accounting).
+*Check:* CT-5, CT-7.
+
+**LIV-8 — Overload shed-and-recover.**
+*Pre:* query pressure exceeding capacity for a finite interval, then subsiding.
+*Bound:* during: typed rejections within P-REJECT-LATENCY ⚠; after: S1-scenario SLOs
+restored within P-RECOVER-BOUND ⚠ with no restart.
+*Witness:* rejection counters (OB-7) rise then stop; latency SLI returns to target.
+*Check:* CT-6, CT-8.
+
+**LIV-9 — Stall budget.**
+*Pre:* work exists (pending chunks with healthy origin, or queued queries).
+*Bound:* zero progress (no commit, no response) for longer than P-STALL-MAX ⚠ never
+occurs silently — either progress resumes or an alarm level (OB-12) is raised.
+*Witness:* progress heartbeat (OB-11) vs alarm state.
+*Check:* CT-7.
+
+**LIV-10 — Graceful shutdown.**
+*Pre:* shutdown requested.
+*Bound:* process exit within P-SHUTDOWN-BOUND; outcome crash-equivalent or better (every
+in-flight query either completes or its client sees a transport close; the store needs
+no repair beyond normal recovery).
+*Witness:* exit code + subsequent clean recovery (CT-2 reuses this).
+*Check:* CT-2.
+
+**LIV-11 — No cross-dataset starvation.**
+*Pre:* ≥2 datasets with pending chunks; one origin path failing, others healthy.
+*Bound:* healthy datasets' commits proceed within LIV-2's bound; a failing chunk delays
+only itself. [Currently violated: the retry backoff is global — GAP-7; probe HZ-2.]
+*Witness:* per-dataset commit progress under partial-fault injection.
+*Check:* CT-8.
+
+**LIV-12 — Metering convergence.**
+*Pre:* healthy registry; an operator's allocation exists on-chain (epoch semantics:
+DEF-22).
+*Bound:* the operator's queries admit within P-EPOCH-POLL + P-CONVERGE-SLACK ⚠ of
+process start or epoch change — allocations are re-read only when the observed epoch
+increases (DEF-22), so a mid-epoch on-chain allocation change becomes effective at the
+next epoch boundary (the cold-start rejection window is bounded — GAP-25 tracks
+shrinking it).
+*Witness:* first admitted query per operator after start; epoch gauge (OB-9).
+*Check:* CT-5.
+
+**LIV-13 — Divergence is convergence-or-alarm.**
+*Pre:* any persistent external contradiction — unfetchable assignment, unfixable chunk
+(commit collision), undeletable eviction target, unreachable registry.
+*Bound:* within P-STALL-MAX ⚠, the condition is either resolved by retry or surfaced as
+a reason-coded alarm (OB-12) while the rest of the worker keeps serving. Silent
+infinite retry of the same failing operation without an alarm is a violation.
+*Witness:* alarm state with reason; continued service on unaffected paths.
+*Check:* CT-4, CT-7.
+
+**LIV-14 — Reclamation keep-up.**
+*Pre:* steady assignment churn at W-CHURN-RATE.
+*Bound:* store size stays within RS-3's amplification bound at all times — reclamation
+keeps pace with eviction; residue and pruned-log space do not trend upward across
+P-SOAK-WINDOW ⚠.
+*Witness:* stored-bytes gauge (OB-5) trend over soak.
+*Check:* CT-7.

--- a/spec/09-failure-model.md
+++ b/spec/09-failure-model.md
@@ -1,0 +1,97 @@
+# 09 — Failure model
+
+Home doc for `FM`. Bands: FM-1..3 global requirements · FM-10..14 assignment-side ·
+FM-20..24 origin-side · FM-30..35 storage & process · FM-40..44 client-side ·
+FM-50..54 operator & auxiliary dependencies.
+
+Response verbs, used in every table:
+
+- **mask** — absorb; the fault is invisible outside internal retries/metrics.
+- **degrade** — reduced but well-defined service, honestly reported.
+- **fail-safe** — refuse the specific operation with a typed error; everything else
+  continues.
+- **alarm** — raise a reason-coded alarm level (OB-12) in addition to any of the above.
+
+## Global requirements
+
+**FM-1 — No externally-triggered termination.** [MUST — intent, currently violated:
+GAP-2] No content arriving from any actor — query bytes, assignment documents, origin
+payloads, log requests, registry responses, schema manifests — may terminate,
+deadlock, or abort the process. The only sanctioned self-terminations: operator
+shutdown, startup refusal on identity mismatch (CN-9) or invalid adopted layout
+(INV-3), and unrecoverable *local* integrity faults where continuing would corrupt
+committed data.
+
+**FM-2 — Transient vs integrity.** [MUST] Every failure path is classified: transient
+(retry under bounded backoff, mask/degrade) or integrity (stop the affected unit,
+alarm, never retry blindly). The classification is per WP-22 on the write path and
+RP-20 on the read path; LIV-13 bounds how long a transient may repeat before alarming.
+
+**FM-3 — Blast-radius containment.** [MUST] A fault's effect is confined to its unit:
+one file → its chunk; one chunk → that chunk's availability; one dataset's origin →
+that dataset's convergence (LIV-11); one query → that query (INV-36); one operator's
+budget → that operator (INV-35); one assignment document → intake of that document
+(WP-2). Store-wide or process-wide effect from a unit fault is a violation.
+
+## Assignment-side faults
+
+| # | Fault | Required response |
+|---|---|---|
+| FM-10 | network-state/assignment endpoint unreachable or slow | mask: retry per WP-1; previous assignment stays in force; alarm past P-STALL-MAX (LIV-13) |
+| FM-11 | document with malformed per-chunk entries (bad address, bad credential) | degrade: affected chunks fail per-chunk (WP-2); rest of the document applies; alarm. [Currently: process panic — GAP-2] |
+| FM-12 | document malformed as a whole, oversized, undecodable, or missing this worker | fail-safe + alarm: reject whole document (WP-2); keep prior assignment; keep serving. [Oversize unbounded today — GAP-4] |
+| FM-13 | equivocating/regressive document (wipes the store, flip-flops) | degrade + alarm: REQ-25 deletion floor holds data; application order is arrival order (NG2) — flip-flops churn but never corrupt |
+| FM-14 | stale document served long-term (worker dropped or endpoint frozen) | degrade + alarm: serve last-applied data honestly; assignment-age observable (OB-13) rises. [No age alarm exists today — GAP-23] |
+
+## Origin-side faults
+
+| # | Fault | Required response |
+|---|---|---|
+| FM-20 | file fetch errors (missing, denied, server error) | mask: WP-13 abort + bounded retry while desired; per-chunk blast radius (FM-3); alarm past P-STALL-MAX |
+| FM-21 | slow or stalling transfers | mask: P-DL-FILE-TIMEOUT / P-DL-STALL-TIMEOUT abort, then as FM-20 |
+| FM-22 | corrupt/truncated payload (wrong bytes for a named file) | fail-safe + alarm: MUST NOT commit (INV-13); quarantine the chunk after bounded retries. [No payload verification exists — GAP-5] |
+| FM-23 | oversized payload (exceeds declared size) | fail-safe: abort the file at the declared-size bound ⚠ (ADR-18); as FM-20 |
+| FM-24 | origin serving for one dataset down, others healthy | degrade: LIV-11 — unaffected datasets converge normally. [Global backoff couples them today — GAP-7] |
+
+## Storage & process faults
+
+| # | Fault | Required response |
+|---|---|---|
+| FM-30 | disk full | degrade + alarm: fetches abort (WP-13); committed data and query service intact; stored-bytes and alarm observables reflect it. Never an infinite silent retry loop (LIV-13) |
+| FM-31 | I/O error on eviction or sweep | degrade + alarm: per-chunk quarantine; retry later. [Currently: process panic — GAP-6] |
+| FM-32 | store content lost/corrupted out-of-band (operator deletion, bit rot, post-power-loss truncation) | fail-safe + alarm: affected chunk leaves service as `server_error`→quarantine, not as client-blamed `bad_request`. [Misclassified today — GAP-5] |
+| FM-33 | process crash at any point (kill, panic, out-of-memory) | recover per CN-3/4/5; INV-40..43 |
+| FM-34 | crash between response send and log append | accepted bounded loss (ADR-13, CN-6); no client-visible effect |
+| FM-35 | log-store record corrupt/undecodable | fail-safe + alarm: skip-and-quarantine the record; log delivery and the process continue (FM-1). [Currently: a decode panic terminates the process — GAP-27] |
+
+## Client-side faults
+
+| # | Fault | Required response |
+|---|---|---|
+| FM-40 | malformed/unparseable query bytes | fail-safe: no response (nothing to bind a signed reply to), no CU, no log (RP-20) |
+| FM-41 | authenticated-but-invalid query (bad signature fields, stale timestamp, illegal envelope) | fail-safe: typed `bad_request`, pre-admission (RP-1) |
+| FM-42 | query flood beyond capacity | degrade: typed `server_overloaded` up to P-REJECT-CONC, then connection drops (ADR-9); recover per LIV-8 |
+| FM-43 | replayed query id | ⚠ currently re-executed and re-charged; intended: fail-safe reject within P-TS-WINDOW (GAP-12) |
+| FM-44 | client disconnects mid-execution | mask: abandon response at transport timeout; SHOULD cancel execution (RP-5). [No cancellation today — GAP-8] |
+
+## Operator & auxiliary dependencies
+
+| # | Fault | Required response |
+|---|---|---|
+| FM-50 | misconfiguration (unparseable addresses, missing required settings) | fail-safe: refuse startup with a diagnostic — never a half-configured worker |
+| FM-51 | second process, different identity, same store | fail-safe: refuse before mutating (CN-9). [Sweep-before-check today — GAP-16] |
+| FM-52 | chain-registry unreachable or erroring | degrade: serve with last-known allocations/epoch; alarm past P-STALL-MAX. [Startup registry error is fatal today — GAP-2 register entry] |
+| FM-53 | schema-registry unreachable or malformed manifest | degrade: keep previously loaded schemas; dynamic-engine queries fail typed `server_error` until first load |
+| FM-54 | worker absent from the on-chain registry at startup | degrade by design: poll the registry and serve nothing until listed; the wait is a visible lifecycle phase (OB-10) with an alarm past P-STALL-MAX (OB-12). [The wait is externally invisible today — GAP-28] |
+
+## Fault → property → test class
+
+| Fault family | Properties exercised | Test class |
+|---|---|---|
+| FM-10..14 | WP-1/2, INV-14, REQ-25, LIV-1/13 | CT-4 (document corpus), CT-3 (churn races) |
+| FM-20..24 | WP-13, INV-13, LIV-2/11, RS-6 | CT-4 + HC-2 fault injection, CT-8 |
+| FM-30..32 | WP-14/22, INV-2/40, LIV-13, RS-4..6 | CT-2, CT-4 (storage-fault injection) |
+| FM-35 | FM-1, CN-6, RP-22 | CT-4 (log-store fault corpus) |
+| FM-33..34 | CN-3..6, INV-40..43 | CT-2 (kill-point matrix) |
+| FM-40..44 | RP-1..5, INV-20/36, LIV-8 | CT-4, CT-9 (fuzz), CT-6 (storm) |
+| FM-50..54 | CN-9, LIV-12, FM-1 | CT-2 (startup corpus), CT-5 |

--- a/spec/10-retention-space.md
+++ b/spec/10-retention-space.md
@@ -1,0 +1,74 @@
+# 10 — Retention and space
+
+Home doc for `RS`. Band: RS-1..9. The worker's disk footprint has two components with
+different lifecycles: the **chunk store** (sized by the assignment) and the **log
+store** (sized by query volume × retention).
+
+**RS-1 — Retention policy.** [MUST] The chunk store retains exactly what the applied
+assignment names — no size-based, age-based, or pressure-based eviction exists. The
+policy table:
+
+| Data | Retained while | Leaves via |
+|---|---|---|
+| committed chunk | in the desired set, or pinned | WP-14 only (INV-11) |
+| transient residue | never intentionally | abort cleanup + recovery sweep (RS-6) |
+| log record | younger than P-LOGS-RETENTION | WP-17 only |
+
+**RS-2 — Availability floor.** [MUST] Eviction never removes: desired chunks, pinned
+chunks (whatever the assignment says), or — per REQ-25 — more than the P-DEL-FLOOR
+fraction of the store per application without operator override ⚠ (ADR-17). Precedence:
+pin > assignment (a pinned undesired chunk stays until released; ADR-16's
+never-interrupt rule is the same precedence applied to application).
+
+**RS-3 — Excess bound (amplification).** [MUST] At every instant,
+`store bytes ≤ live bytes + P-DL-CONC × W-CHUNK-BYTES-MAX + R + G`, where live = bytes
+of desired∪pinned committed chunks, the second term bounds in-flight fetch space, `R` =
+unswept residue (bounded by RS-6), and `G` = evicted-but-unreclaimed bytes (bounded by
+LIV-4's convergence bound × W-CHURN-RATE). ⚠ The bound's slack terms need ratified
+values (ADR-19). The log store is additionally bounded by
+W-LOG-RATE × P-LOGS-RETENTION + the reclamation lag of RS-7.
+
+**RS-4 — Two-phase deletion.** [MUST] Eviction is logically immediate — the chunk
+leaves the namespace and the available set in WP-14's atomic step — and physically
+deferred: byte reclamation follows asynchronously. Between the phases the space counts
+toward `G` (RS-3) and the data is unreachable by every reader (CN-1). A crash between
+phases leaves residue, converged by RS-6.
+
+**RS-5 — Reclamation safety.** [MUST] Physical reclamation is invisible to readers:
+it never touches pinned chunks (their eviction hasn't happened — INV-12), never
+follows a path a reader could still resolve (namespace removal precedes byte removal),
+and never crosses into sibling chunks or foreign entries (CN-10). There is no
+sanctioned reader-free mode; the store always assumes live readers.
+
+**RS-6 — Residue convergence.** [MUST] Transient residue — partial fetches, interrupted
+eviction remnants — is deleted by the abort path when the process survives, and by the
+next recovery sweep otherwise (WP-15). Residue never: becomes adoptable state
+(INV-40), blocks a future commit of the same chunk [violated today — a residual
+committed-name collision wedges the chunk forever: GAP-20], or accumulates across crash
+loops (INV-41). Foreign entries are not residue and are never swept (CN-10).
+
+**RS-7 — Log-store reclamation.** [MUST] Pruned log records' space is reclaimable and
+the log store's on-disk size tracks its live contents within a bounded lag ⚠.
+[Violated today: the store only ever grows to its high-water mark — GAP-10; probe
+HZ-5.]
+Records leave only via WP-17; a schema migration MUST NOT strand prior-generation
+records as permanent dead weight (CN-10).
+
+**RS-8 — Deletion cost bound.** [SHOULD] Eviction work per reconciliation pass is
+proportional to the number of evicted chunks — not to store size — and does not block
+query admission (INV-37). Store-size accounting (OB-5) SHOULD cost o(store entries) per
+observation or be paced below the reconciliation cadence, within the PF-3 maintenance
+budget [today it is a full store walk per loop iteration and per status refresh:
+GAP-15 / HZ-1].
+
+**RS-9 — Interactions.**
+- **× forks:** identical-range chunks are distinct retention units; evicting one never
+  touches the other (INV-3, ADR-4).
+- **× queries:** pins defer, never veto — LIV-4 bounds the deferral after release;
+  RS-2 gives pins precedence meanwhile.
+- **× recovery:** an eviction interrupted before namespace removal un-happens (CN-3
+  re-adoption caveat); one interrupted after converges via RS-6.
+- **× liveness:** reclamation keep-up under churn is LIV-14; failure to reclaim is an
+  alarmed degradation (FM-31), never silent growth (LIV-13).
+- **× disk-full:** FM-30 — eviction and reclamation MUST still proceed when the disk is
+  full (deletion requires no new space), which is the system's self-healing path.

--- a/spec/11-performance.md
+++ b/spec/11-performance.md
@@ -1,0 +1,124 @@
+# 11 — Performance
+
+Home doc for `SLI`, `PF`, `HZ`, and the workload model `W-*`. Bands: SLI-1..8 ·
+PF-1..5 · HZ-1..15.
+
+## SLI definitions
+
+All black-box measurable by the harness (HC-6/HC-9/HC-10).
+
+| # | SLI | Definition (one line) |
+|---|---|---|
+| SLI-1 | query latency | time from query send to last response byte, per outcome class, p50/p95/p99 |
+| SLI-2 | query throughput | successful responses per second at a fixed offered load |
+| SLI-3 | rejection rate | fraction of well-formed queries answered `server_overloaded` or dropped |
+| SLI-4 | download throughput | committed chunk bytes per second while pending work exists |
+| SLI-5 | assignment application latency | publish of a new assignment id → heartbeat reports it applied |
+| SLI-6 | convergence latency | publish → all-zero unavailability map (LIV-1's witness) |
+| SLI-7 | status staleness | state change → change visible in a status read (LIV-6's witness) |
+| SLI-8 | log delivery lag | query response sent → its record retrievable by a collector |
+
+## SLO table
+
+Targets are ⚠ provisional pending ADR-19; baselines are the honest current knowledge
+(measured numbers where the repo records them, "unknown" otherwise — the CT-6 baseline
+run replaces every "unknown").
+
+| SLI | Scenario | Target ⚠ | Known baseline |
+|---|---|---|---|
+| SLI-1 p95 | S1 steady | P-SLO-Q-P95 | unknown; row-oriented encoding dominates cost — columnar+fast-compression measured 18–34× cheaper on the serialization stage (bench branch, fixture chunk) |
+| SLI-1 p99 | S2 query-storm | P-SLO-Q-P99-STORM | unknown |
+| SLI-3 | S1 steady | 0 | assumed ~0; unmeasured |
+| SLI-3 | S2 query-storm | ≤ P-SLO-REJECT-STORM (all typed, none dropped below the ADR-9 bound) | unknown |
+| SLI-4 | S5 backfill | P-SLO-DL-RATE | unknown; bounded by P-DL-CONC and origin |
+| SLI-5 | S3 churn | P-SLO-ASSIGN-APPLY | ≤ ~P-ASSIGN-POLL + fetch time observed informally; unmeasured |
+| SLI-6 | S5 backfill | P-SLO-CONVERGE | unknown |
+| SLI-7 | S1 steady | P-HB-STALENESS | **violated at scale**: the status path walks the full store; "minutes on a busy disk at ~30k chunks" (recorded in the store-walk fix rationale) — GAP-15 |
+| SLI-8 | S1 steady | P-SLO-LOG-LAG (≥ P-LOGS-LAG by construction) | unknown |
+
+## Resource-bound requirements
+
+**PF-1 — Derivable memory ceiling.** [MUST] Peak memory is bounded by a formula over
+configuration: P-MEM-CEIL ⚠ ≈ base + (concurrent queries × the RP-24 per-query multiple
+of P-RESP-MAX) + assignment-document size + fetch buffers. No unbounded queue contributes
+(the execution-queue depth, reject fan-out, and intake queues are all P-bounded; the
+post-admission execution backlog MUST be bounded by P-Q-PAR — GAP-1's fix is a
+precondition).
+
+**PF-2 — End-to-end backpressure.** [MUST] Every producer-consumer edge is bounded:
+transport intake buffers (P-Q-ACCEPT-BUF, P-Q-REQ-BUF, and the lossy shared event queue
+P-EVENT-QUEUE), intake queues (P-Q-QUEUE), execution concurrency (P-Q-PAR), reject
+signing (P-REJECT-CONC), log-read queue (P-LOGS-QUEUE), status reads (P-STATUS-CONC ⚠ —
+unbounded today, GAP-29), fetch concurrency (P-DL-CONC), assignment intake
+(coalesce-to-newest, WP-4). Saturation propagates as typed rejection outward — or a
+transport-level drop at the outer buffers (RP-20's *(no response)* row) — never as
+unbounded buffering inward.
+
+**PF-3 — Maintenance budget, two-sided.** [MUST] Background maintenance (sweeps,
+reclamation, accounting walks) consumes bounded resources (upper side) *and* is
+guaranteed a minimum cadence under load (lower side) so debt cannot grow unboundedly
+(LIV-14). Store-size accounting specifically must not serialize the reconciliation
+loop (RS-8).
+
+**PF-4 — Startup work scheduling.** [MUST] Startup cost is proportional to store size
+only through the recovery scan and residue sweep; neither repeats per loop thereafter.
+Acceptance of queries does not wait on any network dependency (LIV-5).
+
+**PF-5 — Benchmarking regime.** [MUST — harness obligation] CT-6 maintains committed
+baselines for every SLI under S1–S6, characterizes the saturation knee (offered load
+where SLI-1 p99 departs its plateau), includes overload phases (beyond-knee load
+with recovery measurement, LIV-8), and runs the executor-contention probes HZ-8/9. Regressions beyond P-PERF-NOISE gate per MG-6.
+
+## Workload model
+
+| Param | Meaning | Reference value ⚠ |
+|---|---|---|
+| W-CHUNKS | committed chunks in the store | 30 000 (observed scale in fix rationale) |
+| W-DATASETS | datasets in the assignment | 20 |
+| W-CHUNK-BYTES-MAX | largest single chunk | 2 GiB |
+| W-CHUNK-FILES | table files per chunk | 5 |
+| W-QPS | steady offered query load | 50/s |
+| W-QPS-STORM | storm offered load | 20 × W-QPS |
+| W-DL-RATE | healthy origin sustained transfer rate | 100 MiB/s |
+| W-CHURN-RATE | chunks entering/leaving the assignment per hour | 5 % of W-CHUNKS |
+| W-OPERATORS | distinct operators querying | 30 |
+| W-LOG-RATE | log-record bytes per second at W-QPS | derived: W-QPS × mean record size |
+
+Named scenarios (the SLO table's scenario column): **S1 steady** (W-QPS spread over
+W-DATASETS datasets, W-CHUNK-FILES files per chunk, stable assignment) · **S2
+query-storm** (W-QPS-STORM burst, stable assignment) · **S3 assignment-churn**
+(W-CHURN-RATE flips under S1 load) · **S4 cold-start** (restart over W-CHUNKS store
+under S1 load) · **S5 backfill** (empty store, full assignment) · **S6 noisy-neighbor**
+(one dataset's origin failing + one of the W-OPERATORS operators at bucket exhaustion,
+under S1).
+
+## Hazard register
+
+Mechanism → threatened property → probe. Hazards are timeless risk pointers; dated
+defects live in the gap register (13).
+
+| # | Mechanism | Threatens | Probe |
+|---|---|---|---|
+| HZ-1 | full-store accounting walk inside the reconciliation loop | LIV-2/4/6, SLI-7, RS-8 | S4/S5 with W-CHUNKS store: measure loop iteration time vs store size |
+| HZ-2 | global (not per-origin) fetch retry backoff | LIV-11, SLI-4 | S6: one dataset 404s; measure healthy dataset's SLI-4 |
+| HZ-3 | no execution deadline or disconnect cancellation | LIV-3/8, PF-1 | slow-query flood with disconnecting clients; watch slot occupancy |
+| HZ-4 | result built via multiple full-size buffers (uncompressed + compressed + encoded) | PF-1 | concurrent max-size queries; peak RSS vs P-MEM-CEIL |
+| HZ-5 | log-store size high-water behavior | RS-7, LIV-14 | S2 burst then idle soak; on-disk size trend |
+| HZ-6 | assignment application scans the whole network document | SLI-5, PF-2 | apply latency vs document size scaling probe |
+| HZ-7 | status snapshot deep-copies the full chunk sets | SLI-7, HZ-1 interplay | status-read latency vs W-CHUNKS |
+| HZ-8 | blocking filesystem calls on async executors | LIV-6, SLI-1 tail | slow-disk injection (HC-2 delay on store I/O); p99 shift |
+| HZ-9 | compression/signing on shared executor threads | SLI-1 tail under mix | mixed large/small query storm; small-query p99 |
+| HZ-10 | millisecond-resolution transient-name collisions | WP-13 noise, RS-6 | rapid re-fetch of one chunk; abort-storm counter |
+| HZ-11 | pin refcount width vs concurrency ceiling | INV-4/12 | saturation probe pinning one chunk at max concurrency |
+| HZ-12 | unbounded decompression of the assignment document | FM-12, PF-1 | HC-1 serves a decompression bomb; RSS bound |
+| HZ-13 | the auxiliary noise protocol answers any member peer with an unbounded random-byte stream (IB-4) | PF-1/PF-2 margins (egress, CPU) | open N noise streams; egress and CPU stay bounded |
+| HZ-14 | the whole response must be written within P-STREAM-TIMEOUT, so a P-RESP-MAX response needs ≥ P-RESP-MAX / P-STREAM-TIMEOUT (~12.5 MiB/s) reader throughput; slower readers turn large results into resets — and long client-side cooldowns | REQ-1 for large results, SLI-1 tail | throttled-reader driver at max-size responses; reset rate vs reader rate |
+| HZ-15 | flood-shed stream resets (ADR-9) are indistinguishable from timeouts to portals, which apply their longest per-worker cooldown plus a congestion signal — a brief flood can evict the worker from portal pools for minutes | LIV-8 as observed by clients, SLI-3 | CT-6 storm phase: driver mimics portal cooldown policy; measure post-storm re-uptake |
+
+## Benchmark numbers on record
+
+From the repository's benchmark report (bench branch, fixture chunk of 1 397 blocks),
+serialization+compression stage only: the current row-oriented default versus the
+columnar fast path = 34× (blocks table), 21× (logs), 18× (transactions); versus a
+binary row encoding ≈ 13–16×. These motivated ADR-11 and seed the S1 SLI-1 baseline
+once CT-6 first runs.

--- a/spec/12-observability.md
+++ b/spec/12-observability.md
@@ -1,0 +1,88 @@
+# 12 — Observability
+
+Home doc for `OB`. Band: OB-1..14. Signals are named abstractly; the concrete metric
+names, types, and endpoints are IB-30/31. Every signal is pull-readable by the operator
+surface; cardinality is bounded (OB-14).
+
+## Required signals
+
+**OB-1 — Chunk-state gauges.** [MUST] Current sizes of A (available), D (downloading),
+and P (pending). These are the INV-1 witnesses.
+
+**OB-2 — Applied assignment identity.** [MUST] The applied assignment id as reported in
+status (RP-21), readable locally.
+
+**OB-3 — Unavailability summary.** [MUST] Count of desired-but-unavailable chunks (the
+ones-count of DEF-13); zero is the LIV-1 witness.
+
+**OB-4 — Reconciliation counters.** [MUST] Monotonic counters: chunks committed, fetch
+aborts (distinguishing failure from cancellation ⚠ — today conflated, register row
+GAP-17), chunks evicted.
+
+**OB-5 — Space accounting.** [MUST] Stored bytes of the chunk store (RS-3's witness)
+and of the log store (RS-7's witness ⚠ — the latter does not exist today, GAP-17).
+
+**OB-6 — Query concurrency gauge.** [MUST] Currently executing admitted queries.
+[Known-lying today: reads ~0 — GAP-1.]
+
+**OB-7 — Query outcome counters.** [MUST] Admitted-query count by outcome class
+(RP-20), plus pre-admission rejection counters by cause (overload, no-allocation,
+bucket-empty, invalid) ⚠ — pre-admission causes are invisible today (GAP-17).
+
+**OB-8 — Result-size distribution.** [MUST] Histogram of uncompressed result sizes with
+usable buckets ⚠ [today's histograms have no buckets — GAP-17].
+
+**OB-9 — Metering state.** [MUST] Current epoch gauge; per-outcome CU counters
+sufficient to audit INV-15 externally at operator granularity.
+
+**OB-10 — Lifecycle phases.** [MUST] Timestamps/gauges marking: process start, store
+recovery done, on-chain registration confirmed (FM-54), accepting queries (LIV-5
+witness), first assignment applied. [The registration phase is invisible today —
+GAP-28.]
+
+**OB-11 — Progress heartbeat.** [MUST] A signal that distinguishes *idle* (no pending
+work) from *stalled* (pending work, no progress): e.g. last-commit timestamp + pending
+gauge. LIV-9's witness — a monitoring system must be able to derive "stalled for >
+P-STALL-MAX" from exported signals alone.
+
+**OB-12 — Alarm states.** [MUST] Reason-coded, level-readable alarm signals (plus edge
+events in logs) for at least: assessed worker state (DEF-32), assignment intake failing
+(FM-10/12), fetch quarantine (FM-22), eviction/reclamation failure (FM-31), store
+integrity refusal (FM-32), deletion-floor hold (REQ-25). One current-state read answers
+"is anything wrong, and why".
+
+**OB-13 — Assignment age.** [MUST ⚠ — does not exist today: GAP-23] Time since the last
+successfully applied assignment, so a silently-dropped worker is externally detectable
+(FM-14).
+
+**OB-14 — Bounded cardinality.** [MUST] No signal's label space grows with untrusted
+input (per-client or per-chunk labels are forbidden; per-outcome-class and per-dataset
+are the ceiling).
+
+## Property → observable mapping
+
+Every LIV property must be decidable from exported signals:
+
+| Property | Decided by |
+|---|---|
+| LIV-1/2 | OB-1 (P→0), OB-3 (→0), OB-4 commits advancing |
+| LIV-3 | OB-6 returning to baseline, OB-7 outcome advancing |
+| LIV-4 | OB-4 evictions advancing, OB-5 falling |
+| LIV-5 | OB-10 phase timestamps |
+| LIV-6 | OB-2/3 flip latency after a state change |
+| LIV-7 | log delivery lag (SLI-8) via collector-side reconciliation |
+| LIV-8 | OB-7 rejection counters rising then stopping; SLI-1 recovery |
+| LIV-9/13 | OB-11 vs OB-12 (stall must surface as alarm) |
+| LIV-10 | process exit + OB-10 on next start |
+| LIV-11 | OB-4 per run under fault injection (per-dataset commit progress ⚠ — needs a per-dataset breakdown or harness-side inference; GAP-17) |
+| LIV-12 | OB-9 epoch gauge; first-admission timing |
+| LIV-14 | OB-5 trend over soak |
+
+## The lying-metrics rule
+
+For the harness, an incorrect signal is a failure of the same severity as an incorrect
+response: CT runs cross-check every OB gauge/counter against harness-known ground truth
+(injected load, ledger state, model state) and fail on divergence beyond one update
+interval. A metric that cannot be cross-checked is a spec bug — extend the signal or
+the harness until it can. (Current known liars are registered: GAP-1's gauge, GAP-17's
+dead counter and bucketless histograms.)

--- a/spec/13-conformance-tdd.md
+++ b/spec/13-conformance-tdd.md
@@ -1,0 +1,294 @@
+# 13 — Conformance & TDD program
+
+Home doc for `CT`, `MG`, `HC`, `GAP`. **Mutable doc #1.** As of: **2026-07-25**
+(baseline commit `42d9aa1`). Statuses: **C** covered · **P** partial · **U** unchecked;
+`⊘` marks known-violated, `?` known-suspect.
+
+## Harness architecture
+
+```
+ HC-1 scheduler sim ──(network-state, assignments + fault corpus)──▶ ┌─────────┐
+ HC-2 origin stub ────(chunk files; byte LEDGER; fault inject)─────▶ │   SUT   │
+ HC-8 registry stub ──(epoch, allocations)─────────────────────────▶ │ (black  │
+ HC-3 portal driver ──(signed queries, fuzz, disconnects)──────────▶ │  box)   │
+ HC-7 kill/restart ───(SIGKILL at kill-points; power-loss emu)─────▶ └────┬────┘
+                                                                          │
+        HC-5 structural validators ◀── responses, logs, heartbeats ───────┤
+        HC-4 reference model (oracle) ◀── same inputs, replayed ──────────┤
+        HC-6 observability scraper ◀── metrics, status endpoints ─────────┘
+                     │
+              comparator: SUT vs model at QUIESCENCE
+```
+
+**Quiescence** (comparison points): no input events in flight, the progress heartbeat
+(OB-11) and all OB-1 gauges identical across two scrapes ≥ P-QUIESCE-GAP ⚠ apart. The
+ledger in HC-2 makes served bytes the provenance oracle for INV-13/21.
+
+## Reference model (normative pseudocode)
+
+The oracle for CT-1/CT-2/CT-3. Concurrency model: transitions are atomic and
+interleave arbitrarily; the SUT may batch but every observation must equal some legal
+interleaving's state.
+
+```
+state S = { A:set, D:set, N:set, X:doc|⊥, L:map, Q:seq, buckets:map }
+
+apply_assignment(doc):                        # WP-10
+    require valid(doc) and has_slice(doc, self)          # WP-2, else reject whole
+    S.X := doc; S.N := slice(doc, self)                  # A, D, L, Q untouched
+    assert wellformed(S)                                 # INV-1..5
+
+fetch_start(c):                               # WP-11
+    require c in pending(S) and |S.D| < P_DL_CONC
+    S.D += c
+
+commit(c, files):                             # WP-12
+    require c in S.D and files == ledger_bytes(X, c)     # INV-13
+    S.A += c; S.D -= c                                   # atomic visibility (CN-1)
+
+abort(c):                                     # WP-13
+    require c in S.D
+    S.D -= c                                             # residue invisible (RS-6)
+
+evict(c):                                     # WP-14
+    require c in S.A and c not in S.N and S.L[c] == 0    # INV-12
+    require deletion_floor_ok(S)                         # REQ-25 ⚠
+    S.A -= c
+
+recover():                                    # WP-15  (crash may precede)
+    S.A := committed_survivors(); S.D := {}; S.L := {}
+    S.X := ⊥; S.N := S.A; S.Q := durable_records()
+    assert wellformed(S) and no_residue()                # INV-40..42
+
+query(q):                                     # RP path — the read operation
+    if not (sig_ok(q) and fresh(q) and envelope_ok(q)):  return bad_request     # no CU
+    if no_capacity():                                    return server_overloaded
+    if not spend(buckets[op(q)], 1.0):                   return too_many_requests
+    # ---- admitted: exactly one log record from here (INV-32) ----
+    if not post_envelope_ok(q):        out := bad_request
+    elif chunk(q) not in S.A:          out := not_found
+    else:
+        pin(q.chunk)                                     # DEF-12; INV-4
+        r := EVAL(q.body, ledger_bytes(X, q.chunk), clip(q.range, q.chunk))
+        out := downgrade_if_oversized(sign(r))           # RP-14; INV-24
+        unpin(q.chunk)
+    refund(buckets[op(q)], 1.0 - chip(q)) unless out == server_overloaded   # ADR-6
+    S.Q += record(q, out)                                # INV-23: same outcome
+    return out
+
+logs_read(cursor):  return page_after(S.Q, cursor, P_LOGS_RESP_MAX, lag=P_LOGS_LAG)
+status_read():      return snapshot(X.id, unavail_map(S), stored_bytes, epoch)  # INV-30
+```
+
+**Free variables** (the SUT may legitimately vary; everything else must match the
+model): (1) `EVAL`'s output bytes — checked structurally (validators) and, where HC-4
+implements the reference evaluation for a query subset, byte-compared; (2) compression
+byte streams (round-trip equality only); (3) fetch order/timing within WP-3's fairness
+rule; (4) which of several legal interleavings occurred; (5) transient residue naming.
+
+## Test-class taxonomy
+
+| CT | Class | Primary properties | Needs |
+|---|---|---|---|
+| CT-1 | model-conformance property tests (generated transition/query sequences vs the model) | INV-1..5, INV-10..15, INV-20..24, LIV-1/2/4, RP-10..15 | HC-1..5, HC-8, HC-12 |
+| CT-2 | crash-recovery kill-point matrix (kill at every transition edge; double-recovery; power-loss emulation) | INV-40..43, CN-3..5, LIV-5/10, REQ-23 | HC-1/2, HC-7 |
+| CT-3 | concurrency swarms (queries × churn × downloads × status) | INV-4/12/14/21/30/37, LIV-6 | HC-1/2/3, HC-9, HC-12 |
+| CT-4 | input-fault corpus (FM tables, item by item) | FM-10..24, FM-30..32, FM-40..44, INV-36, REQ-24 | HC-1/2/3 injectors |
+| CT-5 | interface conformance (IB tables; response/log/CU accounting reconciliation) | IB-1..44, INV-20/23/25/32, RP-20..22, LIV-7/12, INV-15 | HC-3, HC-5/6, HC-8 |
+| CT-6 | performance benchmarks (S1–S6; knee; overload+recovery) | SLI-1..8, PF-5, LIV-8 | HC-9/10, HC-6 |
+| CT-7 | soak/endurance (crash loops, churn, log growth, stall detection) | LIV-9/13/14, RS-3/6/7, INV-5/41 | HC-9, HC-6, HC-7 |
+| CT-8 | isolation / noisy-neighbor (S6) | INV-35, LIV-11, FM-24 | HC-1/2/8, HC-9 |
+| CT-9 | fuzz (query surface; assignment surface) | REQ-24, FM-40, FM-12, INV-36 | HC-1/3 fuzzers, HC-12 |
+
+## Structural validators (kind-agnostic, every response, no domain knowledge)
+
+decodable per declared format · response signature verifies (INV-25) · `last_block`
+within the requested range per RP-11 · error carries no data (INV-20) · row/block
+membership: every emitted block within `[begin, last_block]` · ascending block order
+(RP-12) · compressed payload round-trips · log pages: cursor-ordered, gap-free vs
+prior page, within retention (INV-5) · heartbeat: map length = assignment slice size,
+ones-count consistent (INV-30) · gauges nonnegative and consistent with set algebra
+(INV-1).
+
+## Traceability matrix (as of 2026-07-25)
+
+Statuses reflect the actual test inventory at `42d9aa1` (39 inline unit tests, 4 of
+them `mvcc-chunks`-gated; no integration tests). WP/RP/CN/RS rows are enforced through the INV/LIV rows that encode
+them (see 07 §reading the catalog).
+
+### Requirements
+
+| ID | CT | Status | Note |
+|---|---|---|---|
+| REQ-1 | CT-1/5 | P | engine-level output tests exist (dynamic engine: format, budget, empty-range); no end-to-end signed-query test |
+| REQ-2 | CT-1/2 | U | no download-pipeline or atomicity test exists |
+| REQ-3 | CT-1/3 | P | set-algebra bookkeeping unit-tested; no eviction-under-load test |
+| REQ-4 | CT-1 | P | last_block semantics unit-tested per engine; resumption equivalence untested |
+| REQ-10 | CT-4 | U | assignment intake wholly untested |
+| REQ-11 | CT-3 | U⊘ | coherence known-violated (GAP-11) |
+| REQ-12 | CT-5 | P | log store ordering/pagination/cleanup unit-tested in memory; durability & reconciliation untested |
+| REQ-13 | CT-5 | U⊘ | known liars: GAP-1 gauge, GAP-17 |
+| REQ-20 | CT-5 | U | the security boundary has zero tests |
+| REQ-21 | CT-1/5 | P | charge/refund/overload-keep unit-tested via mock seams |
+| REQ-22 | CT-6 | U⊘ | concurrency cap inert (GAP-1) |
+| REQ-23 | CT-2 | U | no crash-recovery test exists |
+| REQ-24 | CT-4/9 | U⊘ | known-violated (GAP-2, GAP-4) |
+| REQ-25 | CT-4 | U⊘ | no floor exists (GAP-3) |
+
+### Properties
+
+| ID | CT | Status | Note |
+|---|---|---|---|
+| INV-1 | CT-1 | P | set bookkeeping unit tests (state module) |
+| INV-2 | CT-1/2 | U | store↔state correspondence never tested |
+| INV-3 | CT-2/4 | P | layout parse/overlap/fork unit tests |
+| INV-4 | CT-1/3 | U | pin validity untested; u8-width hazard (GAP-18) |
+| INV-5 | CT-1/7 | P | ordering/pagination unit tests; replay-id hole known (GAP-12) |
+| INV-10 | CT-1 | U | no quiescence test |
+| INV-11 | CT-2 | U | |
+| INV-12 | CT-1/3 | P | retain-if-locked unit-tested; never raced |
+| INV-13 | CT-1 | U⊘ | no payload verification exists (GAP-5) |
+| INV-14 | CT-3 | P | one hand-built interleaving test (feature-gated, not in shipped config — OQ-3) |
+| INV-15 | CT-1/5 | P | unit-tested (charge, refund, overload-keep, fractional put); chip-parse hole GAP-13 |
+| INV-20 | CT-5 | U | |
+| INV-21 | CT-1/3 | U | |
+| INV-22 | CT-1 | P | engine unit tests cover truncation/empty cases; boundary emission unpinned (GAP-32) |
+| INV-23 | CT-5 | P | downgrade-agreement + log-summary unit tests |
+| INV-24 | CT-4/6 | U | boundary corpus absent |
+| INV-25 | CT-5 | U | signing untested |
+| INV-30 | CT-3 | U⊘ | known-violated (GAP-11) |
+| INV-31 | CT-1/6 | U⊘ | known-violated (GAP-1, GAP-17) |
+| INV-32 | CT-5/7 | P⊘ | admitted-always-logged unit-tested; duplicate/oversize drop known (GAP-12/14) |
+| INV-35 | CT-8 | U | |
+| INV-36 | CT-4 | P | panic-containment unit tests (str/String/assert payloads) |
+| INV-37 | CT-3/6 | U | |
+| INV-40 | CT-2 | U | |
+| INV-41 | CT-2/7 | U | |
+| INV-42 | CT-2 | U | |
+| INV-43 | CT-2 | U | |
+| LIV-1 | CT-1/6 | U | |
+| LIV-2 | CT-1 | U | downloader has zero tests |
+| LIV-3 | CT-1/4 | U⊘ | unbounded today (GAP-8) |
+| LIV-4 | CT-1/3 | U⊘ | wake-up gap (GAP-6) |
+| LIV-5 | CT-2/6 | U | |
+| LIV-6 | CT-3/6 | U? | at risk from store walks (GAP-15) |
+| LIV-7 | CT-5/7 | P | pagination/resumption unit-tested in memory |
+| LIV-8 | CT-6/8 | U | client-side cooldown coupling under flood shed: HZ-15 |
+| LIV-9 | CT-7 | U | no stall alarm exists (OB-11/12 partial — GAP-17) |
+| LIV-10 | CT-2 | U | shutdown untested since the subsystem-tree rewrite |
+| LIV-11 | CT-8 | U⊘ | global backoff (GAP-7) |
+| LIV-12 | CT-5 | U | cold-start window known (GAP-25) |
+| LIV-13 | CT-4/7 | U | |
+| LIV-14 | CT-7 | U⊘ | log-store reclamation broken (GAP-10) |
+| FM-1 | CT-4/9 | U⊘ | known-violated (GAP-2) |
+| FM-2..3 | CT-4 | U | |
+| FM-10 | CT-4 | U | |
+| FM-11 | CT-4 | U⊘ | panic path (GAP-2) |
+| FM-12 | CT-4 | U⊘ | unbounded intake (GAP-4) |
+| FM-13 | CT-4 | U⊘ | no floor (GAP-3) |
+| FM-14 | CT-7 | U⊘ | no age signal (GAP-23) |
+| FM-20..21 | CT-4 | U | |
+| FM-22 | CT-4 | U⊘ | no verification (GAP-5) |
+| FM-23 | CT-4 | U | |
+| FM-24 | CT-8 | U⊘ | GAP-7 |
+| FM-30 | CT-4 | U⊘ | disk-full today retries silently forever — no alarm (GAP-17) |
+| FM-31 | CT-4 | U⊘ | panic path (GAP-6) |
+| FM-32 | CT-4 | U⊘ | misclassified as client fault (GAP-5) |
+| FM-33 | CT-2 | U | |
+| FM-34 | CT-2 | U | accepted window (ADR-13) — test bounds it |
+| FM-35 | CT-4 | U⊘ | corrupt log row panics the process (GAP-27) |
+| FM-40..42 | CT-4/9 | U | |
+| FM-43 | CT-4 | U⊘ | replay executes (GAP-12) |
+| FM-44 | CT-4 | U⊘ | no cancellation (GAP-8) |
+| FM-50 | CT-2 | U | |
+| FM-51 | CT-2 | U⊘ | sweep-before-check (GAP-16) |
+| FM-52 | CT-4 | U⊘ | fatal at startup (GAP-2) |
+| FM-53 | CT-4 | P | keep-previous-schemas unit-tested with a live stub server |
+| FM-54 | CT-2 | U | registration wait exists by design; externally invisible (GAP-28) |
+| SLI-1..8 | CT-6 | U | no benchmark harness on the default branch |
+
+## Gap register (as of 2026-07-25)
+
+Priorities: **P0** active production risk · **P1** correctness hole with plausible
+trigger · **P2** bounded/rare · **P3** polish. "First test" = cheapest failing test.
+
+| GAP | Statement | Violates | Pri | First test |
+|---|---|---|---|---|
+| GAP-1 | Query concurrency cap is inert (guard dropped at declaration), so P-Q-PAR is unenforced, the real ceiling is the transport's message-handler product, and the running-query gauge always reads ~0 | RP-4, INV-31, REQ-22, PF-1 | P0 | drive P-Q-PAR+10 slow queries; expect ≥1 `server_overloaded` and a nonzero gauge |
+| GAP-2 | Externally supplied content can terminate the process: a malformed file address in an assignment panics the reconciler; a registry error at startup is fatal; an unparseable roster peer id panics the assignment reader; a pathological per-chunk file count overflows the download-watchdog arithmetic | FM-1, FM-11, FM-52, REQ-24 | P0 | HC-1 assignment containing one bad URL: worker must survive, alarm, and keep serving |
+| GAP-3 | No reconciliation deletion floor: one empty/short assignment wipes the whole store next pass | REQ-25, FM-13, RS-2 | P0 | publish an assignment with zero chunks for the worker: store must survive with an alarm |
+| GAP-4 | Assignment intake is unverified and unbounded: unvalidated binary document parsed unsafely; decompression size uncapped | WP-2, FM-12, REQ-24, HZ-12 | P1 | HC-1 serves a decompression bomb and a truncated document: bounded memory, typed rejection, process alive |
+| GAP-5 | No payload/content verification anywhere: corrupt origin bytes commit (INV-13), power-loss-truncated chunks are adopted (CN-4), and local corruption surfaces as client-blamed `bad_request` (FM-32) | INV-13, CN-4, FM-22, FM-32 | P1 | HC-2 corrupts one file's bytes: commit must be refused (fails today) |
+| GAP-6 | Eviction is fragile: an I/O error panics the process (FM-31), and a chunk unpinned after the eviction pass is not retried until an unrelated event (LIV-4 unbounded) | LIV-4, FM-31, WP-14 | P1 | unassign a pinned chunk, release the pin, inject no further events: bytes must be reclaimed within P-EVICT-BOUND |
+| GAP-7 | Fetch retry backoff is a single global value: one failing chunk throttles every dataset's downloads to P-DL-BACKOFF-MAX | LIV-11, FM-24, WP-13 | P1 | S6: one dataset 404s; healthy dataset's commit rate must stay within LIV-2 bounds |
+| GAP-8 | No execution deadline and no disconnect cancellation: abandoned queries run to completion holding capacity; a slow-query flood converts to sustained overload | LIV-3, RP-5, FM-44, HZ-3 | P1 | disconnect mid-query; capacity slot must free within P-Q-DEADLINE |
+| GAP-9 | Assignment intake head-of-line blocking (shipped build): a persistently failing document fetch is retried at the queue front on a flat interval; newer assignments queue behind it unboundedly | WP-1, LIV-1 | P1 | HC-1: 404 assignment N's document while publishing N+1; worker must converge to N+1 |
+| GAP-20 | A committed-namespace collision (residue or unrecognized dir at a chunk's path) wedges that chunk in an eternal fail-retry loop that also pins the global backoff at max | WP-21, RS-6, LIV-13 | P1 | pre-plant a foreign dir at an assigned chunk's committed path; expect quarantine+alarm, not an infinite loop |
+| GAP-10 | Log-store space is never returned: the reclamation statement after pruning never executes; on-disk size plateaus at the high-water mark | RS-7, LIV-14 | P2 | file-backed store: burst writes, idle past retention, size must shrink |
+| GAP-11 | Status reports can be torn: the availability map is computed against one assignment and labeled with another's id when application races the (slow) snapshot | INV-30, REQ-11 | P2 | race status reads against assignment flips with injected store-walk latency |
+| GAP-12 | Query-id replay is not prevented: a replayed signed query re-executes and re-charges, and its log record is silently dropped on the id collision | RP-2, INV-32, FM-43 | P2 | replay an identical query within P-TS-WINDOW: expect rejection; today observe double charge + one log |
+| GAP-13 | The metering chip is derived by parsing the chunk id (contradicting ADR-4): an id outside the legacy pattern silently charges full price | INV-15, DEF-24 | P2 | query 5 % of a chunk whose id defies the legacy pattern: net spend must be 0.05 |
+| GAP-14 | Worker log records hash the uncompressed result; portal-side records hash compressed bytes — systematic cross-audit mismatch | INV-23 (margin), OQ-5 | P2 | blocked by OQ-5 decision |
+| GAP-15 | Store-size accounting walks the entire store inside the reconciliation loop and again per status refresh: at scale, downloads serialize behind minutes-long walks and status staleness explodes | RS-8, LIV-6, SLI-7, HZ-1 | P2 | W-CHUNKS-scale store with slow-I/O injection: SLI-7 within P-HB-STALENESS |
+| GAP-16 | No single-instance enforcement, and the residue sweep runs before the identity check — a mis-keyed second process destroys the incumbent's in-flight fetches before refusing | CN-9, FM-51 | P2 | start a second process with a different key: incumbent's transient state must be untouched |
+| GAP-17 | Observability defects: pre-admission rejection causes uncounted (dead no-allocation counter), histograms bucketless, abort causes conflated, no log-store size signal, no stall alarm, and outcome counters record the pre-downgrade outcome (a too-large/unsignable result counts `ok` while wire and log say `server_error`) | OB-4/5/7/8, INV-31, LIV-9 | P2 | CT-5 metrics cross-check per the lying-metrics rule |
+| GAP-22 | Execution logs (full query text, client ids) are served to any network member without authorization | RP-22 trust model | P2 | policy decision, then an authz conformance test |
+| GAP-23 | No assignment-age observable: a worker silently dropped from assignments serves stale data indefinitely with no alarm | OB-13, FM-14 | P2 | freeze HC-1: alarm level must rise within P-STALL-MAX |
+| GAP-24 | The SQL surface bypasses the result-size budget (whole result materialized), reports last_block = 0, echoes full query text into error strings, and ignores the message's `block_range` entirely | RP-14 (margin), IB-12 | P2 | SQL query with a large result: memory bound and typed downgrade |
+| GAP-25 | Metering cold start: until the first registry poll completes, every query is rejected no-allocation with no retry hint | LIV-12 | P2 | first admitted query per operator within LIV-12's bound after start |
+| GAP-18 | Pin refcount is a narrow fixed-width counter (HZ-11); beyond ~255 concurrent pins of one chunk it wraps and un-protects the chunk (latent; reachable only via misconfiguration once GAP-1 is fixed) | INV-4 | P3 | saturation probe at the configured ceiling |
+| GAP-19 | No machine-readable subcodes: `not_found` collapses never-assigned / not-yet-fetched / evicted, and `bad_request` collapses attempt-scoped causes (signature, freshness) with request-scoped ones — portals treat every `bad_request` as a terminal client error, so worker clock skew beyond P-TS-WINDOW surfaces as client-visible rejects with no reroute | RP-20 | P2 | subcode conformance once designed; interim: skewed-clock worker in the harness must not convert valid client queries into terminal errors |
+| GAP-21 | Metering bucket: division-by-zero latent at astronomically high allocations; an inverted predicate name invites future inversion bugs; an operator address shared by two clusters has its bucket reset to zero tokens on refresh | INV-15 (margin) | P3 | unit boundary test at the allocation ceiling |
+| GAP-26 | Advisory merge gates (MG-2..6) must be promoted to blocking as their HC capabilities land | MG-2..6 | P2 | per-gate: flip to blocking in the same change that completes its HC row |
+| GAP-27 | A corrupt/undecodable log-store record panics log delivery, and the fail-fast tree (ADR-14) turns that into process termination | FM-1, FM-35, INV-43 (margin) | P2 | plant a malformed row in the log store; a logs pull must skip-and-alarm with the process alive |
+| GAP-28 | The operator surface binds only after on-chain registration and registry init complete, so the registration wait (FM-54) is externally indistinguishable from a hung start; no lifecycle phase or alarm marks it | OB-10, LIV-5 (witness) | P3 | start against a registry stub that never lists the worker: HTTP surface up, waiting phase visible |
+| GAP-29 | Status requests spawn unbounded concurrent handler tasks; the P-STATUS-CONC bound in PF-2's inventory does not exist | PF-2, RP-24 | P3 | status-request flood: handler concurrency bounded by P-STATUS-CONC |
+| GAP-30 | The anchor-mismatch verdict (stale continuation parent hash) — load-bearing for portal fork recovery — is carried only in the legacy engine's `server_error` message text, which RP-20 declares unstable; portals parse the exact string, so any wording change silently converts client-side conflict recovery into terminal errors | RP-20 (anchor verdict), OQ-7 | P1 | CT-5: a stale-anchor query yields a machine-distinguishable verdict; interim regression pins the exact string (IB-13) |
+| GAP-31 | The two oversize paths emit divergent `server_error` strings (`Response too large` at the engine's uncompressed cap vs `query result too large` at the encoded-message downgrade); portals special-case only the former, so the latter degrades to a terminal generic failure client-side | RP-14, IB-13 | P2 | drive both oversize paths; assert one verdict surface |
+| GAP-32 | Boundary emission (RP-11) is provided by the legacy engine's weight-0 pinning but is unverified for the dynamic engine; if the dynamic engine returns zero records for an evaluated-but-unmatched range, portal-side client resumption breaks the moment portals adopt it | RP-11 (boundary emission) | P1 | both engines: a selective query matching nothing over an evaluated range returns the boundary records, last record = coverage cursor |
+
+## Build order
+
+1. **Phase 0 — harness skeleton**: HC-1/2/3/8 stubs + HC-5 validators + HC-12 seeding;
+   one end-to-end smoke (assign → download → query → verify → logs pull). Unblocks
+   every U row above.
+2. **Phase 1 — P0 gaps**: failing tests for GAP-1/2/3, then fixes. MG-4 becomes
+   meaningful here.
+3. **Phase 2 — correctness core**: HC-4 reference model; CT-1 property runs; CT-2
+   kill-point matrix (HC-7); CT-5 accounting reconciliation. Burn P1 gaps.
+4. **Phase 3 — robustness**: CT-3 swarms, CT-4 full corpus, CT-9 fuzz; P2 gaps.
+5. **Phase 4 — performance regime**: HC-9/10, CT-6 baselines (replace every "unknown"
+   in 11), CT-7/8; ratify ADR-19; promote MG-5/6.
+   Every phase ends by updating this matrix and register.
+
+## Merge gates
+
+| MG | Gate | Threshold | When | Enforced by | Blocking? |
+|---|---|---|---|---|---|
+| MG-1 | spec integrity: the suite's linter reports zero errors | P-GATE-SPEC-ERR | per-PR | HC-13 | **yes** |
+| MG-2 | property-coverage ratchet: no matrix row regresses; a PR adding a REQ/INV/LIV/FM/SLI adds its row and CT class in the same change | P-GATE-PROP-RATCHET | per-PR | HC-13 (row-completeness) + review | advisory → GAP-26 |
+| MG-3 | line coverage: diff ≥ P-COV-DIFF, repo floor ≥ P-COV-TOTAL, ratchet-up only | P-COV-DIFF, P-COV-TOTAL | per-PR | HC-11 | advisory → GAP-26 |
+| MG-4 | PR conformance subset: CT-1 (bounded run), CT-4, CT-5 green within P-GATE-PR-TIME | P-GATE-PR-TIME | per-PR | HC-1..5 | advisory → GAP-26 |
+| MG-5 | deep classes: CT-2/3/7/8/9 green | P-GATE-NIGHTLY | nightly | HC-7, HC-9 | advisory → GAP-26 |
+| MG-6 | performance: every SLI within P-PERF-NOISE of its committed baseline | P-PERF-NOISE | nightly + pre-release | HC-10 | advisory → GAP-26 |
+| MG-7 | static: formatter clean, lint at the pinned deny level, dependency audit | P-GATE-LINT | per-PR | HC-14 | **yes** |
+| MG-8 | failing-test-first for every GAP closure and bug fix (register's "first test" column), plus flake policy: P-FLAKE-RETRY retries, then quarantine with owner + expiry — never silent skip | P-FLAKE-RETRY | per-PR (review checklist) | HC-14 + review | **yes** (by review) |
+
+## Harness capability register
+
+| HC | Capability | Needed by | Status | Note |
+|---|---|---|---|---|
+| HC-1 | scheduler simulator: network-state + assignment documents, fault corpus (IB-40/41) | CT-1..4, CT-8/9, MG-4/5 | U | |
+| HC-2 | data-origin stub with byte ledger + injectors: delay, stall, error, corrupt, oversize (IB-42) | CT-1..4, CT-8, MG-4/5 | U | ledger = provenance oracle |
+| HC-3 | portal driver: keys, signed queries, disconnector, fuzzer (IB-10) | CT-1, CT-3..5, CT-9, MG-4 | U | inline mock seams exist for controller unit tests; not a driver |
+| HC-4 | reference model as executable oracle (§model) | CT-1..3 | U | |
+| HC-5 | structural validators (§validators) | CT-1..5, MG-4 | U | |
+| HC-6 | observability scraper + quiescence gate | CT-5..7 | U | |
+| HC-7 | kill/restart harness with kill-point + power-loss emulation | CT-2, CT-7, MG-5 | U | |
+| HC-8 | chain-registry stub: epochs, allocations (IB-43) | CT-1, CT-5, CT-8 | U | |
+| HC-9 | load/swarm driver | CT-3, CT-6..8, MG-5 | U | |
+| HC-10 | benchmark runner, committed baselines, noise band | CT-6, MG-6 | U | bench-branch harness exists off-mainline; not wired |
+| HC-11 | coverage instrumentation in CI | MG-3 | U | |
+| HC-12 | deterministic seeding; seed recorded on failure | CT-1, CT-3, CT-9 | U | |
+| HC-13 | spec linter (`tools/check_spec.py`) wired in CI | MG-1, MG-2 | **C** | this suite's standing gate |
+| HC-14 | static CI toolchain: build, unit tests, formatter, pinned lint level | MG-7, MG-8 | **C** | exists on the default branch |

--- a/spec/14-interface-binding.md
+++ b/spec/14-interface-binding.md
@@ -1,0 +1,179 @@
+# 14 — Interface binding
+
+Home doc for `IB`. Bands: IB-1..9 transport · IB-10..19 query surface · IB-20..29 logs
+and status surface · IB-30..39 operator surface · IB-40..49 input-side binding.
+
+This is the only normative document that names the concrete surface. Everything here is
+*observable contract*; internals remain out of scope. **Anything not specified here is
+unspecified — do not pin it in tests.** Binding changes update this file and CT-5 in
+the same change (IB-9).
+
+## Transport
+
+**IB-1 — Peer transport.** The worker serves libp2p request/response protocols over
+QUIC. The worker's network identity is its libp2p peer id; signature keys are the peer
+identity keys. Peers are additionally gated by the network's on-chain membership
+whitelist at the transport layer.
+
+**IB-2 — Protocol table.**
+
+| Protocol id | Request | Response | Max request | Max response | Stream read/write timeout |
+|---|---|---|---|---|---|
+| `/sqd/query/1.1.0` | `Query` (protobuf) | `QueryResult` | P-Q-MSG-MAX | P-RESP-MAX | P-STREAM-TIMEOUT |
+| `/sqd/sql_query/1.0.0` | `Query` (query = base64url Substrait plan) | `QueryResult` | P-SQL-MSG-MAX | P-RESP-MAX | P-STREAM-TIMEOUT |
+| `/sqd/worker_logs/1.1.0` | `LogsRequest` | `QueryLogs` | 100 B | P-LOGS-RESP-CEIL | P-STREAM-TIMEOUT |
+| `/sqd/worker_status/1.0.0` | (empty) | `Heartbeat` | 0 B | P-LOGS-RESP-CEIL | P-STREAM-TIMEOUT |
+
+Transport-level violations (oversized, undecodable, empty body, queue overflow) produce
+stream resets with no typed response — the RP-20 *(no response)* row. The intake chain
+per protocol is: accept buffer (P-Q-ACCEPT-BUF) → parsed-request queue (P-Q-REQ-BUF) →
+shared lossy event queue (P-EVENT-QUEUE, drops counted by the transport's dropped-events
+metric) → the per-surface intake queue (P-Q-QUEUE); overflow at any stage is such a
+drop.
+
+**IB-4 — Auxiliary protocols.** The transport additionally serves: libp2p identify
+(agent string `sqd-worker/<version>`), Kademlia DHT in server mode, autonat, ping, and
+`/sqd/noise/0.0.1` — a bandwidth-probe endpoint that answers any member peer with an
+unbounded random-byte stream (resource hazard: HZ-13). These carry no application
+semantics and are outside the conformance surface; tests MUST NOT pin their behavior
+beyond existence.
+
+**IB-3 — Status is pull-only.** No broadcast/heartbeat publishing exists; the status
+protocol answers with a cached snapshot (ADR-16). The `Heartbeat` message is unsigned
+(OQ-4).
+
+**IB-9 — Versioning rule.** Protocol ids version the surface; a wire-visible change
+bumps the protocol id or a message field number, never silently changes semantics of an
+existing field. This file and the CT-5 conformance corpus change in the same commit.
+
+## Query surface
+
+**IB-10 — `Query` message fields.**
+
+| Field | Type | Binding semantics |
+|---|---|---|
+| `query_id` | string | MUST be exactly 36 bytes (signature payload precondition); portal-chosen; unique per query (RP-2, GAP-12) |
+| `dataset` | string | exact match against assignment dataset ids |
+| `query` | string | engine-specific body; interpretation per `query_engine` |
+| `chunk_id` | string | opaque exact-match key (DEF-3) |
+| `block_range` | `{begin, end}` uint64 | required in practice (absence → post-admission `bad_request`); overrides any range in the query body (the SQL surface ignores it — GAP-24) |
+| `timestamp_ms` | uint64 | freshness check window P-TS-WINDOW |
+| `signature` | bytes | covers fields per RP-2 |
+| `compression` | enum `GZIP(0) / NONE(1) / ZSTD(2)` | response encoding; proto default = GZIP; **not** signature-covered |
+| `query_engine` | enum `DEFAULT(0) / DYNAMIC(1)` | engine selector; signature-covered |
+| `output_format` | enum `JSONL(0) / ARROW_IPC(1)` | ARROW_IPC legal only with DYNAMIC; signature-covered |
+| `request_id` | string | echoed into the log record; otherwise ignored |
+
+**IB-11 — `QueryResult`.** `query_id`, oneof `ok {data, last_block}` /
+`err {bad_request | not_found | server_error | too_many_requests | server_overloaded}`,
+optional `retry_after_ms`, `signature`. `retry_after_ms` appears on overload/bucket
+rejections; the admission-time slow-down advisory MAY additionally ride on any
+post-admission response — success or error (RP-4, test-pinned). Downgraded results
+carry none.
+
+**IB-12 — Output formats.** `JSONL`: one JSON object per line, ascending block order.
+`ARROW_IPC`: per-table Arrow IPC streams, raw binary columns, no Arrow-level
+compression (response-level compression applies instead; ADR-11). SQL surface: JSONL
+rows of the plan's result; `last_block` is 0 (a signed constant — SQL results carry no
+progress semantics; register row GAP-24).
+
+**IB-13 — Error mapping.** Abstract class (RP-20) → wire variant, and the signed
+payload:
+
+| Abstract | Wire | Signature covers |
+|---|---|---|
+| `bad_request` | `err.bad_request(string)` | query id + class code (message text unauthenticated) |
+| `not_found` | `err.not_found(string)` | query id + class code |
+| `too_many_requests` | `err.too_many_requests` | query id + class code |
+| `server_overloaded` | `err.server_overloaded` | query id + class code |
+| `server_error` | `err.server_error(string)` | query id + class code |
+| success | `ok` | query id ‖ sha3-256(compressed payload bytes) ‖ last_block |
+
+⚠ Two `server_error` message strings are de-facto frozen contracts until GAP-30/31
+resolve (OQ-7): `unexpected base block: expected …, but got …#0x…` (the anchor-mismatch
+verdict, RP-20 — portals convert it into their fork-recovery conflict) and
+`Response too large` (the engine-level oversize verdict — portals convert it into a
+narrow-the-query rejection).
+
+## Logs and status surface
+
+**IB-20 — `LogsRequest`.** `{from_timestamp_ms, last_received_query_id?}` — the DEF-14
+cursor. Response `QueryLogs{queries_executed[], has_more}`; page bounded by
+P-LOGS-RESP-MAX (a margin below P-LOGS-RESP-CEIL; OQ-2). Records ordered by
+⟨timestamp_ms, query_id⟩; only records with `timestamp_ms ≤ now − P-LOGS-LAG` are
+served. The response is unsigned; record authenticity rests on each record's embedded
+client-signed query.
+
+**IB-21 — `QueryExecuted` record.** Client id, the full original `Query` (signature
+included), `exec_time_micros`, a stage-timing report (parse/exec/serialize/compress/
+sign), receipt-side `timestamp_ms`, `worker_version`, and oneof
+`ok {uncompressed_data_size, sha3-256(uncompressed data), last_block}` / the RP-20
+error. Note the hash-basis asymmetry with IB-13's success signature (OQ-5).
+
+**IB-22 — `Heartbeat` message.** `{version, assignment_id, missing_chunks: BitString,
+stored_bytes?, current_epoch?, last_applied_assignment_id?}`. `missing_chunks` is the
+DEF-13 map, deflate-compressed bit bytes with declared size and ones-count; bit order
+is chunk-ref order (OQ-1). `assignment_id` is `""` before the first application.
+`last_applied_assignment_id` is absent in shipped builds (OQ-3).
+
+## Operator surface
+
+**IB-30 — HTTP endpoints.** Bound on the operator port (default 8000), unauthenticated,
+GET only: `/worker/status` → JSON `{"state":{"available":n,"downloading":n}}` ·
+`/worker/peer-id` → text peer id · `/metrics` → OpenMetrics text.
+
+**IB-31 — Metric names.** The OB signals bind to Prometheus families, all labeled
+`worker_id`: `chunks_available/downloading/pending` (OB-1),
+`chunks_downloaded/failed_download/removed` counters (OB-4), `used_storage_bytes`
+(OB-5), `running_queries` (OB-6), `num_queries_executed{status}` (OB-7),
+`query_result_size_bytes` (OB-8), `worker_status{worker_status}` (OB-12 assessed-state
+component), `worker_info_info{version}`. Signals OB-9/10/11/13 and the missing OB-4/7
+breakdowns have no binding yet — GAP-17/GAP-23 track the additions.
+
+**IB-32 — Configuration surface.** Flags/env (defaults live in the registry):
+
+| Setting | Env | Binds |
+|---|---|---|
+| `--data-dir` | `DATA_DIR` | store root (required) |
+| `--prometheus-port` | `PROMETHEUS_PORT` | IB-30 port |
+| `--p2p-port` / `--public-ip` | `LISTEN_PORT` / `PUBLIC_IP` | transport addresses |
+| `--key` | `KEY_PATH` | identity key file (required) |
+| `--parallel-queries` | `PARALLEL_QUERIES` | P-Q-PAR |
+| `--concurrent-downloads` | `CONCURRENT_DOWNLOADS` | P-DL-CONC |
+| `--query-threads` | `QUERY_THREADS` | engine pool width |
+| `--assignment-url` | `ASSIGNMENT_URL` | network-state document address |
+| (positional) | `S3_TIMEOUT` / `S3_READ_TIMEOUT` | P-DL-FILE-TIMEOUT / P-DL-STALL-TIMEOUT |
+| (positional) | `DOWNLOADS_MAX_DELAY_SEC` | P-DL-BACKOFF-MAX |
+| (positional) | `ASSIGNMENT_CHECK_INTERVAL_SEC` / `ASSIGNMENT_FETCH_TIMEOUT_SEC` / `ASSIGNMENT_CHECK_MAX_DELAY_SEC` | P-ASSIGN-POLL / P-ASSIGN-FETCH-TIMEOUT / P-ASSIGN-RETRY-MAX |
+| (positional) | `NETWORK_POLLING_INTERVAL_SEC` | P-EPOCH-POLL |
+| `--query-schemas-url` (+ refresh env) | `QUERY_SCHEMAS_URL` | schema registry address / P-SCHEMA-REFRESH |
+| `--rpc-url`, `--l1-rpc-url`, `--network`, contract addresses | `RPC_URL` … | chain registry |
+| (positional) | `SENTRY_DSN` / `SENTRY_IS_ENABLED` | crash telemetry (on by default) |
+
+Duration settings parse as whole seconds. Misconfiguration behavior is FM-50.
+
+## Input-side binding (what simulators/stubs implement)
+
+**IB-40 — Network-state document.** HTTPS GET at the assignment URL returning JSON
+`{network, assignment: {id, fb_url_v1, effective_from, …}}`; `effective_from` is
+currently ignored by the worker (OQ-8). HC-1 serves this.
+
+**IB-41 — Assignment document.** HTTPS GET at `fb_url_v1`: a gzip-compressed
+FlatBuffers document — dataset table (ids, base addresses), per-dataset chunk tables
+(id, base address, file name→address map, declared size, summaries, per-chunk
+worker-index lists — the live chunk→worker mapping), worker roster (peer ids, assessed
+state, encrypted HTTP headers per worker; the roster-side chunk list is deprecated;
+encryption is crypto-box against the worker's identity key). HC-1 must be able to emit
+well-formed and deliberately malformed instances (FM-11/12 corpus).
+
+**IB-42 — Data origin.** Plain HTTPS GET per file at
+`join(dataset_base, chunk_base, file_url)` with the decrypted headers attached;
+redirects disabled; per-request timeout P-DL-FILE-TIMEOUT, read stall bound
+P-DL-STALL-TIMEOUT. HC-2 serves these and ledgers every byte.
+
+**IB-43 — Chain registry reads.** Worker id lookup by peer id at startup; epoch number
+and per-operator CU allocations polled every P-EPOCH-POLL. HC-8 stubs these.
+
+**IB-44 — Schema registry.** HTTPS GET YAML manifest mapping dataset types to schema
+documents, refreshed every P-SCHEMA-REFRESH with unchanged-body short-circuit; fetch
+failure keeps previous schemas (FM-53).

--- a/spec/15-parameters.md
+++ b/spec/15-parameters.md
@@ -1,0 +1,110 @@
+# 15 — Parameter registry
+
+**Mutable doc #2.** As of: 2026-07-25, baseline `42d9aa1`. Every `P-*` symbol used
+anywhere in the suite has a row. **Observed** = what the implementation does today
+(configuration default where operator-settable). **Target** = the intended bound; ⚠ =
+proposed, unratified — ratification lands via the ADR named in the row (ADR-19 for the
+batch unless stated).
+
+## Assignment intake
+
+| Parameter | Role | Observed | Target |
+|---|---|---|---|
+| P-ASSIGN-POLL | network-state poll period (WP-1) | 60 s | same |
+| P-ASSIGN-FETCH-TIMEOUT | assignment document fetch timeout (WP-1) | 300 s | same |
+| P-ASSIGN-RETRY-BASE | intake retry backoff base (WP-1) | 1 s (poll stage); document stage retries flat at 1 s — GAP-9 | jittered exponential both stages ⚠ |
+| P-ASSIGN-RETRY-MAX | intake retry backoff cap (WP-1) | 14 400 s | same |
+| P-ASSIGN-SIZE-MAX | decompressed assignment size bound (WP-2, HZ-12) | **unbounded** — GAP-4 | 512 MiB ⚠ (ADR-18) |
+
+## Downloads
+
+| Parameter | Role | Observed | Target |
+|---|---|---|---|
+| P-DL-CONC | concurrent chunk fetches (WP-11) | 3 | same |
+| P-DL-FILE-TIMEOUT | per-file fetch timeout; chunk watchdog = × file count (WP-13) | 60 s | same |
+| P-DL-STALL-TIMEOUT | per-read stall bound (WP-13) | 3 s | same |
+| P-DL-BACKOFF-BASE | fetch retry backoff base (WP-13) | 100 ms | same |
+| P-DL-BACKOFF-MAX | fetch retry backoff cap (WP-13) | 300 s, **global scope** — GAP-7 | 300 s, per-origin scope ⚠ |
+
+## Query service
+
+| Parameter | Role | Observed | Target |
+|---|---|---|---|
+| P-Q-PAR | concurrent executing queries (RP-4) | 20 configured, **not enforced** — GAP-1; effective ceiling = 2 × P-Q-STREAMS | 20, enforced ⚠ |
+| P-Q-QUEUE | intake queue depth per protocol surface (RP-4) | 16 | same |
+| P-Q-STREAMS | concurrent message handlers per protocol surface (RP-4) | 32 | same |
+| P-Q-ACCEPT-BUF | transport accept buffer per protocol surface (IB-2) | 128 | same |
+| P-Q-REQ-BUF | transport parsed-request queue per protocol surface (IB-2) | 128 | same |
+| P-EVENT-QUEUE | shared transport→worker event queue, lossy with drop counting (IB-2, PF-2) | 100 | same |
+| P-STATUS-CONC | concurrent status-read handlers (RP-24) | **unbounded** — GAP-29 | 16 ⚠ |
+| P-REJECT-CONC | concurrent rejection-signing bound (ADR-9) | 64 | same |
+| P-Q-DEADLINE | per-query execution deadline (RP-5, LIV-3) | **none** — GAP-8 | 55 s ⚠ (OQ-6 — strictly below the portal's 60 s per-attempt abandonment) |
+| P-Q-MSG-MAX | query message ceiling (IB-2) | 4 MiB + 1 KiB | same |
+| P-SQL-MSG-MAX | SQL-surface message ceiling (IB-2) | 257 KiB | same |
+| P-RESP-MAX | uncompressed result ceiling (RP-14); transport response ceiling (IB-2) | 250 MiB | same |
+| P-RESP-BUDGET | engine early-stop result budget (RP-13) | 20 MiB | same |
+| P-RETRY-HINT | retry-after on overload rejections (RP-4) | 1 000 ms | same |
+| P-TS-WINDOW | query timestamp freshness window (RP-1) | 60 s | same |
+| P-STREAM-TIMEOUT | transport stream read/write timeout (IB-2) | 20 s | same |
+| P-MEM-CEIL | process memory ceiling, derivable per PF-1 | unmeasured; per-query peak ≈ 3 × result size (HZ-4) | formula ratified with ADR-19 ⚠ |
+
+## Metering
+
+| Parameter | Role | Observed | Target |
+|---|---|---|---|
+| P-CU-BURST | token-bucket capacity (DEF-23) | 3.0; latent edge defects tracked in GAP-21 | same |
+| P-EPOCH-POLL | registry poll period (LIV-12) | 30 s | same |
+
+## Status and logs
+
+| Parameter | Role | Observed | Target |
+|---|---|---|---|
+| P-HB-INTERVAL | status snapshot refresh period (RP-21) | 60 s | same |
+| P-HB-STALENESS | status staleness bound (LIV-6, SLI-7) | violated at scale: refresh + full store walk, "minutes" observed at ~30k chunks — GAP-15 | 90 s ⚠ |
+| P-LOGS-RETENTION | log-record retention (WP-17) | 2 h | same |
+| P-LOGS-LAG | log serving lag floor (RP-22, DEF-14) | 60 s | same |
+| P-LOGS-RESP-MAX | log response page budget (RP-22) | 10 MiB − 100 KiB (margin unexplained — OQ-2) | derive from P-LOGS-RESP-CEIL ⚠ |
+| P-LOGS-RESP-CEIL | transport ceiling for log/status responses (IB-2) | 10 MiB | same |
+| P-LOGS-QUEUE | log-read queue depth (RP-22) | 4 | same |
+| P-SCHEMA-REFRESH | schema-manifest refresh period (IB-44) | 3 600 s | same |
+
+## Lifecycle and reconciliation bounds
+
+| Parameter | Role | Observed | Target |
+|---|---|---|---|
+| P-START-ACCEPT | start → accepting queries (LIV-5) | unmeasured; recovery scan + residue sweep dominate | 120 s at W-CHUNKS ⚠ |
+| P-EVICT-BOUND | pin-release → reclamation (LIV-4) | **unbounded** — GAP-6 | 60 s ⚠ |
+| P-STALL-MAX | zero-progress-with-work alarm bound (LIV-9/13) | no alarm exists — GAP-17 | 600 s ⚠ |
+| P-DEL-FLOOR | max store fraction deletable per application without override (REQ-25) | no floor — GAP-3 | 50 % ⚠ (ADR-17) |
+| P-CONVERGE-SLACK | scheduling slack in convergence bounds (LIV-1/12) | — | 60 s ⚠ |
+| P-RECOVER-BOUND | overload-end → SLOs restored (LIV-8) | unmeasured | 60 s ⚠ |
+| P-REJECT-LATENCY | rejection response latency under storm (LIV-8) | unmeasured | 1 s ⚠ |
+| P-SHUTDOWN-BOUND | shutdown drain bound (LIV-10) | 5 s (+1 s executor drain) | same |
+| P-SOAK-WINDOW | soak-trend evaluation window (LIV-14) | — | 24 h ⚠ |
+| P-QUIESCE-GAP | scrape gap defining harness quiescence (13) | — | 5 s ⚠ |
+
+## SLO targets (all ⚠ until ADR-19; baselines in 11)
+
+| Parameter | Role | Observed | Target |
+|---|---|---|---|
+| P-SLO-Q-P95 | SLI-1 p95, S1 | unmeasured | 2 s ⚠ |
+| P-SLO-Q-P99-STORM | SLI-1 p99, S2 | unmeasured | 10 s ⚠ |
+| P-SLO-REJECT-STORM | SLI-3 ceiling, S2 | unmeasured | typed-only; ≤ overflow fraction ⚠ |
+| P-SLO-DL-RATE | SLI-4 floor, S5 | unmeasured | 0.8 × min(W-DL-RATE, P-DL-CONC × per-fetch rate) ⚠ |
+| P-SLO-ASSIGN-APPLY | SLI-5 bound, S3 | unmeasured | P-ASSIGN-POLL + P-ASSIGN-FETCH-TIMEOUT + 60 s ⚠ |
+| P-SLO-CONVERGE | SLI-6 bound, S5 | unmeasured | LIV-1 formula ⚠ |
+| P-SLO-LOG-LAG | SLI-8 bound, S1 | ≥ P-LOGS-LAG by construction | P-LOGS-LAG + 60 s ⚠ |
+
+## Merge-gate thresholds
+
+| Parameter | Role | Observed | Target |
+|---|---|---|---|
+| P-GATE-SPEC-ERR | MG-1: allowed linter errors | 0 (enforced in CI) | 0 |
+| P-GATE-PROP-RATCHET | MG-2: matrix regression allowance | row-completeness enforced; ratchet manual | 0 regressions ⚠ |
+| P-COV-DIFF | MG-3: changed-line coverage floor | not instrumented | 80 % ⚠ |
+| P-COV-TOTAL | MG-3: whole-repo coverage floor | not instrumented | 60 %, ratchet-up ⚠ |
+| P-GATE-PR-TIME | MG-4: PR-gate wall-clock budget | — | 10 min ⚠ |
+| P-GATE-NIGHTLY | MG-5: nightly-suite budget | — | 4 h ⚠ |
+| P-PERF-NOISE | MG-6: benchmark noise band | — | 5 % ⚠ |
+| P-FLAKE-RETRY | MG-8: retry budget before quarantine | — | 1 ⚠ |
+| P-GATE-LINT | MG-7: pinned lint deny level | formatter + lint at deny(correctness, suspicious) | same |

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,102 @@
+# SQD Network Worker — behavioral specification
+
+The worker is a node of a decentralized data lake. It continuously reconciles a local
+chunk store against a network-published assignment — downloading assigned data chunks
+from a data origin and deleting unassigned ones — and serves signed, metered data
+queries against the chunks it holds, while reporting its status and delivering
+execution logs to network collectors.
+
+This suite specifies what the worker MUST do (not how the current code does it), records
+why it is that way (the decision log), and carries a full conformance program: a
+reference model as test oracle, a test-class taxonomy, a traceability matrix, and a
+prioritized gap register capturing where today's implementation deviates from intent.
+
+**Tier: conformance (full depth). Shape: stateful service.** The worker owns persistent
+state (the chunk store and the query-log store), mutates it from an input stream
+(assignments, downloads), and answers queries — the classic stateful-service module set
+applies: mutations (04), query contract (05), consistency/durability (06), and a
+retention/space lifecycle (10).
+
+## Document map
+
+| Doc | Contents | Normative? |
+|---|---|---|
+| [01-overview.md](01-overview.md) | context, actors, goals, non-goals, trust model, lifecycle | Yes |
+| [02-requirements.md](02-requirements.md) | product requirements `REQ`, open questions `OQ` | Yes |
+| [03-data-model.md](03-data-model.md) | definitions `DEF`: entities, state tuple, input events | Yes |
+| [04-mutations.md](04-mutations.md) | write path `WP`: reconciliation loop, transition catalog | Yes |
+| [05-queries.md](05-queries.md) | read path `RP`: admission, result contract, error taxonomy | Yes |
+| [06-consistency-durability.md](06-consistency-durability.md) | `CN`: commit model, isolation, recovery contract | Yes |
+| [07-invariants.md](07-invariants.md) | safety catalog `INV` | Yes |
+| [08-liveness.md](08-liveness.md) | liveness catalog `LIV` | Yes |
+| [09-failure-model.md](09-failure-model.md) | fault families and required responses `FM` | Yes |
+| [10-retention-space.md](10-retention-space.md) | space lifecycle `RS`: deletion, reclamation, residue | Yes |
+| [11-performance.md](11-performance.md) | `SLI`/SLOs, workload model `W-*`, hazards `HZ`, benchmarking `PF` | Yes |
+| [12-observability.md](12-observability.md) | required signals `OB`, property→observable mapping | Yes |
+| [13-conformance-tdd.md](13-conformance-tdd.md) | reference model, `CT` taxonomy, matrix, gaps `GAP`, gates `MG`, harness `HC` | **Mutable** |
+| [14-interface-binding.md](14-interface-binding.md) | concrete wire/HTTP/config surface `IB` | Yes |
+| [15-parameters.md](15-parameters.md) | parameter registry `P-*` | **Mutable** |
+| decisions/ | ADR log, one file per decision | Append-only |
+
+## Conventions
+
+- **RFC 2119**: MUST / MUST NOT / SHOULD / MAY have their standard meanings. A tag like
+  `[MUST — intent, currently violated: GAP-n]` states intended behavior the current
+  implementation does not meet; the deviation is tracked in the gap register, never by
+  weakening the requirement.
+- **IDs** are stable and never renumbered. Prefixes and home documents:
+  `REQ`/`OQ` → 02 · `DEF` → 03 · `WP` → 04 · `RP` → 05 · `CN` → 06 · `INV` → 07 ·
+  `LIV` → 08 · `FM` → 09 · `RS` → 10 · `PF`/`SLI`/`HZ` → 11 · `OB` → 12 ·
+  `CT`/`MG`/`HC`/`GAP` → 13 · `IB` → 14 · `P-*` → 15 · `ADR` → decisions/.
+  Numbering is **banded** per category (bands are declared in each home doc's header);
+  holes between bands are the convention working, not missing entries.
+- **Parameters**: every constant (timeout, budget, cap, threshold) appears in normative
+  text only as a `P-NAME` symbol. Concrete values — observed and target — live only in
+  [15-parameters.md](15-parameters.md). ⚠ marks a provisional value awaiting
+  ratification via an ADR.
+- **Math notation**: ℕ for naturals, ⊥ for "absent", `\` for set difference, ∪ ∩ ⊆ as
+  usual; ⟨…⟩ for tuples; sequences are ordered multisets.
+- **Mutability rule**: exactly two documents carry dates and statuses —
+  13-conformance-tdd.md and 15-parameters.md. `decisions/` only ever gains files; an
+  accepted ADR is never edited except to gain `Superseded by ADR-n`. All other documents
+  change only when *intended behavior* changes.
+- **Scope tags** on invariants: `[state]` holds in every observable state ·
+  `[transition]` relates consecutive states · `[response]` holds for every result ·
+  `[recovery]` holds across crash/restart.
+
+## Decision log
+
+| ADR | Title | Status |
+|---|---|---|
+| [ADR-1](decisions/ADR-1-pull-based-assignment-distribution.md) | Pull-based assignment distribution | Accepted (historical) |
+| [ADR-2](decisions/ADR-2-binary-assignment-format.md) | Binary assignment format over JSON | Accepted (historical) |
+| [ADR-3](decisions/ADR-3-skip-assignment-verification.md) | Skip assignment document verification | Accepted (historical) |
+| [ADR-4](decisions/ADR-4-opaque-chunk-identity.md) | Opaque chunk identity, suffix forks | Accepted (historical) |
+| [ADR-5](decisions/ADR-5-panic-containment-at-engine-boundary.md) | Panic containment at the engine boundary | Accepted (historical) |
+| [ADR-6](decisions/ADR-6-fractional-compute-units.md) | Fractional compute units: charge then refund | Accepted (historical) |
+| [ADR-7](decisions/ADR-7-admission-bar-ordering.md) | Admission bar: reserve before spend; rejects unlogged | Accepted (historical) |
+| [ADR-8](decisions/ADR-8-single-outcome-delivery.md) | Response and log built from a single outcome | Accepted (historical) |
+| [ADR-9](decisions/ADR-9-bounded-reject-fanout.md) | Bounded reject fan-out | Accepted (historical) |
+| [ADR-10](decisions/ADR-10-lock-ordering-discipline.md) | Lock ordering: assignment index before chunk state | Accepted (historical) |
+| [ADR-11](decisions/ADR-11-engine-selection-and-arrow-output.md) | Engine selection by wire enum; columnar output format | Accepted (historical) |
+| [ADR-12](decisions/ADR-12-single-chunk-query-scope.md) | Single-chunk query scope | Accepted (historical) |
+| [ADR-13](decisions/ADR-13-respond-before-logging.md) | Respond before logging | Accepted (historical) |
+| [ADR-14](decisions/ADR-14-fail-fast-subsystem-tree.md) | Fail-fast subsystem tree | Accepted (historical) |
+| [ADR-15](decisions/ADR-15-identity-stamp-not-instance-lock.md) | Identity stamp, not an instance lock | Accepted (historical) |
+| [ADR-16](decisions/ADR-16-opaque-assignment-ids-pull-only-status.md) | Opaque assignment ids; pull-only status | Accepted (historical) |
+| [ADR-17](decisions/ADR-17-reconciliation-deletion-floor.md) | Reconciliation deletion floor | Proposed |
+| [ADR-18](decisions/ADR-18-bounded-validated-assignment-intake.md) | Bounded, validated assignment intake | Proposed |
+| [ADR-19](decisions/ADR-19-ratify-provisional-targets.md) | Ratify provisional SLO targets and gate thresholds | Proposed |
+
+## How to use this suite
+
+1. **Ratify**: review the three `Proposed` ADRs and every ⚠ target in
+   [15-parameters.md](15-parameters.md); acceptance turns ⚠ into committed bounds.
+2. **Build the harness** in the order given in
+   [13-conformance-tdd.md](13-conformance-tdd.md) §build order: input simulators and
+   structural validators first, then the reference model, then the kill/restart harness.
+3. **Burn down the gap register** priority-first; every closure lands with the failing
+   test named in its "first test" column.
+4. Keep the suite honest: run `python3 spec/tools/check_spec.py spec/` (the standing
+   gate, wired in CI) — it fails on dangling IDs, unregistered parameters, matrix holes,
+   and decision-log drift.

--- a/spec/decisions/ADR-1-pull-based-assignment-distribution.md
+++ b/spec/decisions/ADR-1-pull-based-assignment-distribution.md
@@ -1,0 +1,23 @@
+# ADR-1 — Pull-based assignment distribution
+
+Status: Accepted (historical)
+
+## Context
+
+Early versions pushed assignments to workers over the p2p layer (gossipsub broadcast;
+a scheduler among the boot nodes). Gossipsub's memory cost on workers was significant,
+and push fan-out ties scheduler availability to fleet convergence. The gossip protocol
+was first disabled by default, then removed outright ("Reduce RAM by removing gossipsub
+protocol"), and the scheduler was dropped from the boot nodes.
+
+## Decision
+
+Workers pull: poll a CDN-hosted network-state document on a fixed interval, and fetch
+the referenced assignment document when its id changes. No push path exists.
+
+## Consequences
+
+Convergence latency is bounded below by the poll interval (P-ASSIGN-POLL) — accepted.
+Scheduler and workers are decoupled through static content that scales to any fleet
+size. Assignment freshness becomes the worker's responsibility to monitor (OB-13,
+FM-14). Shapes WP-1, REQ-10, LIV-1.

--- a/spec/decisions/ADR-10-lock-ordering-discipline.md
+++ b/spec/decisions/ADR-10-lock-ordering-discipline.md
@@ -1,0 +1,24 @@
+# ADR-10 — Lock ordering: assignment index before chunk state
+
+Status: Accepted (historical)
+
+## Context
+
+The state manager guards two locks: the applied-assignment index and the chunk-set
+state. A refactor merged two functions without aligning their acquisition orders,
+producing a textbook AB-BA deadlock in production (worker hung: no downloads, no
+status). The fix commit established a single canonical order.
+
+## Decision
+
+The canonical acquisition order is: assignment index → chunk state (→ the
+assignment-application tracker, where that feature is compiled in). Every code path
+that takes more than one of these locks takes them in this order; no lock is held
+across a suspension point.
+
+## Consequences
+
+The deadlock class is closed while the discipline holds — but it is documented only
+here and in a commit message, with no test or lint enforcing it (the gap register's
+concurrency rows and CT-3 are the intended guard). Any new lock joins the order
+explicitly or the invariant silently becomes three-way false. Shapes INV-37, CT-3.

--- a/spec/decisions/ADR-11-engine-selection-and-arrow-output.md
+++ b/spec/decisions/ADR-11-engine-selection-and-arrow-output.md
@@ -1,0 +1,29 @@
+# ADR-11 — Engine selection by wire enum; columnar output format
+
+Status: Accepted (historical)
+
+## Context
+
+Row-oriented JSON output dominated query cost. The repository's benchmark report
+(bench branch, fixture chunk) measured the serialization+compression pipeline at
+18–34× cheaper with Arrow IPC + zstd than JSONL + gzip; Protobuf and FlatBuffers were
+evaluated and rejected (smaller but slower end-to-end; no zero-copy benefit since the
+response is compressed anyway). A second query engine ("dynamic") with schema-driven
+dataset support needed a rollout path that doesn't break old clients.
+
+## Decision
+
+The query message carries two orthogonal enums: `query_engine` (DEFAULT → legacy
+engine; DYNAMIC → the schema-driven engine) and `output_format` (JSONL; ARROW_IPC,
+legal only with DYNAMIC). Protobuf's zero-default makes old clients land on
+legacy+JSONL automatically. Both enums are covered by the query signature. Arrow-level
+compression stays off — the worker compresses the whole response. Gating is
+portal-driven: no worker-side flag disables the dynamic engine; the schema registry
+(CDN manifest, hourly refresh, keep-previous-on-failure) is the operational gate.
+
+## Consequences
+
+Backward-compatible phased rollout (workers → portal → SDKs); the measured 18–34×
+serialization headroom becomes reachable. Rejected alternative recorded: the report
+also recommended zstd level 1; the worker ships the library default level instead —
+an open easy win. Shapes RP-12, IB-10/12, REQ-1.

--- a/spec/decisions/ADR-12-single-chunk-query-scope.md
+++ b/spec/decisions/ADR-12-single-chunk-query-scope.md
@@ -1,0 +1,23 @@
+# ADR-12 — Single-chunk query scope
+
+Status: Accepted (historical)
+
+## Context
+
+A query could conceivably span every chunk the worker holds for a dataset. That makes
+result size, execution time, snapshot semantics, and billing granularity all
+store-shaped instead of request-shaped, and couples portals' routing to worker-local
+layout.
+
+## Decision
+
+Every query addresses exactly one chunk, named by id. Portals plan multi-chunk reads
+by fanning out one query per chunk (network-wide, across workers) and resuming within
+a chunk via `last_block`.
+
+## Consequences
+
+Read isolation collapses to a single pin (DEF-15) — no multi-chunk snapshot machinery.
+Metering per chunk-fraction is well-defined (DEF-24). Portals own range planning.
+`num_read_chunks`-style signals are constant by construction. Shapes NG1, RP-10,
+CN-2.

--- a/spec/decisions/ADR-13-respond-before-logging.md
+++ b/spec/decisions/ADR-13-respond-before-logging.md
@@ -1,0 +1,23 @@
+# ADR-13 — Respond before logging
+
+Status: Accepted (historical)
+
+## Context
+
+The log append is a synchronous durable write on the response path's tail. Ordering it
+before the send would add store-write latency to every query and couple client-visible
+latency to log-store health. The in-code rationale: "Send before logging … the
+durable write stays off the response path."
+
+## Decision
+
+The wire response is sent first; the log record is appended after. A crash between the
+two loses the records of responses already sent in that window.
+
+## Consequences
+
+Query latency excludes the durable write. The loss window is an accountability gap
+(served work the worker cannot prove — unpaid), never a client-correctness gap.
+Accepted as bounded and rare; CT-2 must measure, not eliminate, it (FM-34). Also
+forces the log lag floor P-LOGS-LAG, since record order and timestamp order can
+disagree near the head. Shapes WP-16, CN-6, RP-22.

--- a/spec/decisions/ADR-14-fail-fast-subsystem-tree.md
+++ b/spec/decisions/ADR-14-fail-fast-subsystem-tree.md
@@ -1,0 +1,25 @@
+# ADR-14 — Fail-fast subsystem tree
+
+Status: Accepted (historical)
+
+## Context
+
+The worker is a set of long-running loops (transport, queries, assignment intake,
+reconciliation, status, logs, metering). A hand-rolled supervisor macro ran them with
+ad-hoc lifetimes; partial-death states (one loop dead, the rest serving) are worse
+than a clean restart under a process supervisor, because a half-alive worker keeps
+its network reputation while silently not doing its job.
+
+## Decision
+
+All loops run under a supervision tree; any subsystem exiting for a reason other than
+requested shutdown is an error that tears down the whole process (bounded by
+P-SHUTDOWN-BOUND, plus a short executor drain so stuck blocking tasks cannot hold the
+exit).
+
+## Consequences
+
+Whole-process fail-fast makes FM-1 the load-bearing requirement it is: every panic
+anywhere becomes an outage, so panic paths in loops are P0-class bugs (GAP-2, GAP-6).
+Operators get clean restart semantics; there is no half-alive mode. Shapes FM-1,
+LIV-10.

--- a/spec/decisions/ADR-15-identity-stamp-not-instance-lock.md
+++ b/spec/decisions/ADR-15-identity-stamp-not-instance-lock.md
@@ -1,0 +1,23 @@
+# ADR-15 — Identity stamp, not an instance lock
+
+Status: Accepted (historical)
+
+## Context
+
+A data directory reused under a different network identity would serve one identity's
+data under another's signatures. Full single-instance locking (advisory file locks,
+PID files) was not implemented — no commit records why; the stamp guards the observed
+failure mode (key mix-ups in operator setups).
+
+## Decision
+
+The store carries a plain-text identity stamp; a process whose identity differs
+refuses to start. Nothing prevents two processes with the *same* identity from sharing
+a store.
+
+## Consequences
+
+Key mix-ups fail fast. Same-identity double-start remains undefined behavior on a
+shared store, and the current refusal runs after recovery has already swept transient
+state — both tracked (GAP-16); CN-9 specifies the intended check-before-mutate order.
+Shapes CN-9, FM-51.

--- a/spec/decisions/ADR-16-opaque-assignment-ids-pull-only-status.md
+++ b/spec/decisions/ADR-16-opaque-assignment-ids-pull-only-status.md
@@ -1,0 +1,26 @@
+# ADR-16 — Opaque assignment ids; pull-only status
+
+Status: Accepted (historical)
+
+## Context
+
+Coordinating "which assignment is a worker on" needs either worker-side ordering
+semantics or scheduler-side ones. The PR record (staged-assignment work) states the
+choice explicitly: the id "is an opaque String. Worker does not parse, compare, or
+order assignment IDs. Assignment ordering remains scheduler-owned." Relatedly, status
+broadcast was removed with the gossip layer (ADR-1); worker-to-worker status requests
+were also dropped.
+
+## Decision
+
+The worker: treats assignment ids as opaque; applies assignments in arrival order,
+never interrupting an application in progress; coalesces a backlog to the newest; and
+reports the previously applied id while a newer one is being applied. Status is served
+only on request, from a periodically refreshed snapshot.
+
+## Consequences
+
+The worker stays simple and the scheduler owns global ordering (NG2). Honest-but-stale
+reporting is legal within P-HB-STALENESS; the reporting-coherence hole (GAP-11) and
+the shipped-build coalescing hole (GAP-9) are deviations from this decision's intent,
+not amendments to it. Shapes WP-4, RP-21, NG2.

--- a/spec/decisions/ADR-17-reconciliation-deletion-floor.md
+++ b/spec/decisions/ADR-17-reconciliation-deletion-floor.md
@@ -1,0 +1,25 @@
+# ADR-17 — Reconciliation deletion floor
+
+Status: Proposed
+
+## Context
+
+Reconciliation deletes whatever the assignment stops naming. A scheduler bug, a
+truncated document, or a worker briefly missing from the roster therefore wipes a
+multi-terabyte store in one pass — a fleet-wide amplifier with hours-to-days of
+re-download cost. An earlier code comment ("prevent accidental massive removals")
+acknowledged the risk; the guard was never built and the comment was lost in a
+refactor. Trade-off: any floor delays legitimate large rebalances.
+
+## Decision
+
+Proposed: a single assignment application may evict at most the P-DEL-FLOOR fraction
+of the store's chunks. Beyond it, eviction pauses, an alarm level raises (OB-12), and
+the excess is re-evaluated on the next intake cycle; an explicit operator override
+releases the hold for sanctioned rebalances.
+
+## Consequences
+
+A wipe becomes a held, alarmed, recoverable state instead of an accident. Legitimate
+mass rebalances need an override or several cycles. Encodes REQ-25, RS-2; closes
+GAP-3 when accepted and implemented.

--- a/spec/decisions/ADR-18-bounded-validated-assignment-intake.md
+++ b/spec/decisions/ADR-18-bounded-validated-assignment-intake.md
@@ -1,0 +1,29 @@
+# ADR-18 — Bounded, validated assignment intake
+
+Status: Proposed
+
+## Context
+
+ADR-3 accepted skipping document verification when the verifier cost over a minute.
+Since then: the panic on a malformed per-chunk address is proven remote-triggerable
+(GAP-2), decompression is unbounded (GAP-4/HZ-12), file names from the document reach
+filesystem paths without traversal checks, and origin payloads commit unverified
+(GAP-5). The one-minute measurement predates the binary-format rework and has not
+been re-taken.
+
+## Decision
+
+Proposed: (a) cap decompressed document size at P-ASSIGN-SIZE-MAX; (b) re-measure
+verified parsing on current documents — adopt it if within an acceptable intake
+budget, else validate structurally on access (every address parse, name sanitization,
+bounds check degrades per-chunk, never panics); (c) verify fetched files against the
+assignment's declared sizes at commit time, quarantining mismatches (FM-22/23); (d)
+harden recovery to quarantine-and-alarm unrecognized or colliding chunk directories
+instead of wedging (GAP-20) or failing startup wholesale.
+
+## Consequences
+
+FM-1/REQ-24 become achievable; per-chunk blast radius (FM-3) becomes real on the
+intake path. Costs: bounded extra intake latency, a size field honored at commit, and
+a quarantine mechanism with an operator surface. Supersedes ADR-3's risk acceptance
+once accepted (ADR-3 then gains its supersession mark).

--- a/spec/decisions/ADR-19-ratify-provisional-targets.md
+++ b/spec/decisions/ADR-19-ratify-provisional-targets.md
@@ -1,0 +1,24 @@
+# ADR-19 — Ratify provisional SLO targets and gate thresholds
+
+Status: Proposed
+
+## Context
+
+The suite introduces bounds that exist nowhere today: liveness bounds (P-Q-DEADLINE,
+P-EVICT-BOUND, P-STALL-MAX, P-START-ACCEPT, …), the SLO-target symbols, the memory
+ceiling formula (P-MEM-CEIL), and merge-gate thresholds (P-COV-DIFF, P-COV-TOTAL,
+P-PERF-NOISE, P-FLAKE-RETRY, P-GATE-PR-TIME, P-GATE-NIGHTLY, P-GATE-PROP-RATCHET).
+Every ⚠ row in 15-parameters.md whose row does not name another ADR belongs to this
+batch. The numbers proposed there are engineering estimates, not measurements.
+
+## Decision
+
+Proposed: run the CT-6 baseline suite (S1–S6) once the Phase-0 harness exists, replace
+every "unmeasured" observation in the registry with data, then ratify each target —
+adjusting where baselines prove the estimate wrong. Gate thresholds ratchet upward
+only after ratification.
+
+## Consequences
+
+Targets become commitments with evidence; the registry's ⚠ marks disappear in one
+reviewed change. Until then, all ⚠ bounds are advisory and MG-6 cannot block.

--- a/spec/decisions/ADR-2-binary-assignment-format.md
+++ b/spec/decisions/ADR-2-binary-assignment-format.md
@@ -1,0 +1,23 @@
+# ADR-2 — Binary assignment format over JSON
+
+Status: Accepted (historical)
+
+## Context
+
+Assignments were JSON. At network scale, parsing dominated intake: a commit records
+"the JSON parsing takes much more time than fetching with some setups", which had
+forced repeated retuning of fetch timeouts (30 s → 90 s → 1200 s) because the timeout
+covered parsing too.
+
+## Decision
+
+The assignment document is a gzip-compressed FlatBuffers file (`fb_url_v1`); the worker
+holds the buffer and reads it zero-copy through index handles. The fetch timeout was
+rescoped to the network fetch only.
+
+## Consequences
+
+Intake cost is dominated by transfer, not parsing. The worker keeps the whole
+network-wide document in memory (HZ-6: applying scans all datasets × chunks).
+Zero-copy reading motivated skipping buffer verification — see ADR-3. Shapes WP-1/2,
+IB-41.

--- a/spec/decisions/ADR-3-skip-assignment-verification.md
+++ b/spec/decisions/ADR-3-skip-assignment-verification.md
@@ -1,0 +1,21 @@
+# ADR-3 — Skip assignment document verification
+
+Status: Accepted (historical)
+
+## Context
+
+FlatBuffers offers a verifying parse and an unchecked one. On real network-scale
+assignments the verifier "took more than a minute" per intake (commit rationale), on a
+document fetched every change over HTTPS from network-operated infrastructure.
+
+## Decision
+
+Parse the assignment with the unchecked reader. Trust rests on transport security and
+the operator of the assignment endpoint.
+
+## Consequences
+
+Intake is fast. A corrupted or hostile document reaches an unverified binary reader —
+undefined behavior is theoretically in scope, and the decompressed size is unbounded
+(GAP-4). The spec keeps REQ-24 as intent and ADR-18 proposes the bounded/validated
+replacement; until then this ADR records the accepted risk. Shapes WP-2, FM-12.

--- a/spec/decisions/ADR-4-opaque-chunk-identity.md
+++ b/spec/decisions/ADR-4-opaque-chunk-identity.md
@@ -1,0 +1,24 @@
+# ADR-4 — Opaque chunk identity, suffix forks
+
+Status: Accepted (historical)
+
+## Context
+
+Chunk ids originally encoded the block range, and the read path derived range facts
+(e.g. a result's `last_block`) from the id. That conflation produced a family of
+duplicate-id and wrong-progress defects, and made chunk replacement (same range, new
+content — forks) impossible. The PR record states: "The chunk id shouldn't be used as a
+source of truth for the data that it corresponds to."
+
+## Decision
+
+The chunk id is an opaque lookup key. Block-range truth comes from the query's range
+and the chunk's content. Two chunks may cover the identical range (suffix-distinguished
+forks); partially overlapping ranges remain illegal. Empty results report the
+requested range's end.
+
+## Consequences
+
+Chunk replacement and forks become possible; a whole defect class retires. Layout
+validation must special-case identical ranges (INV-3). One residual violation: the
+metering chip still parses the id (GAP-13). Shapes DEF-3, RP-11, INV-3.

--- a/spec/decisions/ADR-5-panic-containment-at-engine-boundary.md
+++ b/spec/decisions/ADR-5-panic-containment-at-engine-boundary.md
@@ -1,0 +1,22 @@
+# ADR-5 — Panic containment at the engine boundary
+
+Status: Accepted (historical)
+
+## Context
+
+A panic inside the query-engine thread pool aborted the whole process (rayon pool
+panics are not recoverable by the caller), taking down every in-flight query and the
+node's network presence — hit in production. Alternatives: run queries in
+subprocesses (heavy), or guarantee panic-freedom upstream (unenforceable across
+engine dependencies).
+
+## Decision
+
+Every engine invocation is wrapped in a panic-catching boundary; a panic becomes a
+typed `server_error` for that query only, with the payload preserved in the message.
+
+## Consequences
+
+One malicious or buggy query cannot end service (INV-36, G4). Panics outside the
+boundary (result compression, signing, response plumbing) still escalate — the
+boundary's edges are a standing test target (CT-4). Shapes INV-36, FM-1.

--- a/spec/decisions/ADR-6-fractional-compute-units.md
+++ b/spec/decisions/ADR-6-fractional-compute-units.md
@@ -1,0 +1,24 @@
+# ADR-6 — Fractional compute units: charge then refund
+
+Status: Accepted (historical)
+
+## Context
+
+Charging the actual covered fraction at admission would let a portal issue many tiny
+queries for the price of one, overloading the worker while paying almost nothing —
+admission cost must reflect *work admitted*, not work eventually done. But flat
+per-query pricing overcharges partial-chunk queries.
+
+## Decision
+
+Admission spends a full 1.0 CU up front; after execution the unused fraction
+(1 − chip) is refunded, regardless of success or error. A post-admission overload
+rejection keeps the whole unit — a deliberate reversal of the original refund-on-
+overload behavior (changed in the p2p-hardening rework, pinned by test): admission
+capacity was consumed, and refunding it would make overloading the worker free.
+
+## Consequences
+
+Burst abuse is priced at full CUs; honest partial queries net-pay their fraction.
+Overload keeps are a small overcharge under pressure — accepted. The chip computation
+still parses chunk ids (GAP-13). Shapes DEF-23/24, INV-15, REQ-21, RP-4.

--- a/spec/decisions/ADR-7-admission-bar-ordering.md
+++ b/spec/decisions/ADR-7-admission-bar-ordering.md
@@ -1,0 +1,24 @@
+# ADR-7 — Admission bar: reserve before spend; rejects unlogged
+
+Status: Accepted (historical)
+
+## Context
+
+Before the admission rework, a query could be charged and then dropped on a full
+queue (spent unit, no service), and rejection paths could silently drop the request
+with no typed response. Logging rejected queries would let unauthenticated or
+unfunded traffic grow the log store.
+
+## Decision
+
+Admission order is fixed: validate identity/freshness/envelope → reserve a queue slot
+→ spend the CU. A spent unit therefore always corresponds to an enqueued query.
+Everything past admission is billable and always logged; everything rejected before it
+produces a typed signed error (or a drop, per ADR-9) and no log record.
+
+## Consequences
+
+CU spend and service admission cannot diverge (INV-15). Rate-limit and overload
+pressure before admission is invisible in the log store by design — it must be
+observable via metrics instead (OB-7; the missing counters are GAP-17). Shapes RP-1,
+DEF-25, INV-32.

--- a/spec/decisions/ADR-8-single-outcome-delivery.md
+++ b/spec/decisions/ADR-8-single-outcome-delivery.md
@@ -1,0 +1,22 @@
+# ADR-8 — Response and log built from a single outcome
+
+Status: Accepted (historical)
+
+## Context
+
+The wire response and the log record were built by separate code paths; they could
+disagree — a result recorded as success but delivered as an error (oversize discovered
+late), or a served query missing from the log. Billing disputes are adjudicated from
+logs, so divergence is unauditable.
+
+## Decision
+
+One function produces both halves of the delivery from one execution outcome. A
+result that cannot be shipped (oversized, unsignable) is downgraded to `server_error`
+in the response *and* the log, atomically at build time.
+
+## Consequences
+
+INV-23 becomes structurally enforceable and cheap to test. Residual asymmetry: a
+built-then-undeliverable response (transport failure after build) still logs as
+success — accepted, bounded by transport timeouts. Shapes DEF-26, INV-23, RP-14.

--- a/spec/decisions/ADR-9-bounded-reject-fanout.md
+++ b/spec/decisions/ADR-9-bounded-reject-fanout.md
@@ -1,0 +1,22 @@
+# ADR-9 — Bounded reject fan-out
+
+Status: Accepted (historical)
+
+## Context
+
+Every typed rejection is signed. Under a query flood, unbounded concurrent signing
+tasks would let an attacker convert cheap requests into expensive signature work — a
+self-inflicted denial of service. The in-code rationale: past the bound, "the response
+is dropped — a cheap stream reset — rather than spawning unbounded signing tasks under
+a flood."
+
+## Decision
+
+Concurrent rejection signing is capped (P-REJECT-CONC). Beyond the cap, the connection
+is dropped with no response.
+
+## Consequences
+
+Flood cost stays bounded; graceful degradation ends at the cap — portals beyond it see
+transport resets instead of retry hints (RP-20's *(no response)* row), which is
+accepted as the flood posture. Shapes RP-4, FM-42.

--- a/spec/tools/check_spec.ignore
+++ b/spec/tools/check_spec.ignore
@@ -1,0 +1,8 @@
+# Suppressions for spec/tools/check_spec.py — format: check | file-glob | message-regex
+#
+# Every entry MUST carry a written justification on the comment line above it,
+# naming who accepted the deviation and why. Suppressions are for judgment calls
+# on tuned checks — never for silencing a check that was not first tuned in the
+# checker itself.
+#
+# (no entries)

--- a/spec/tools/check_spec.py
+++ b/spec/tools/check_spec.py
@@ -1,0 +1,873 @@
+#!/usr/bin/env python3
+"""Standing quality gate for the worker spec suite (spec/).
+
+Single file, stdlib only. Enforces the conventions the suite itself declares
+(README §Conventions): reference integrity, dead weight, traceability coverage,
+decision-log consistency, normative shape, freshness.
+
+Usage: check_spec.py [SPEC_DIR] [--format text|json|github] [--severity E|W|I]
+                     [--only CHECK[,CHECK]] [--strict] [--no-ignore] [--list-checks]
+Exit: 1 if error-severity findings survive (or any finding with --strict),
+      2 on bad usage, 0 otherwise.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import defaultdict
+
+# ----------------------------------------------------------------------------
+# Configuration — the suite's declared conventions (README.md §Conventions).
+# ----------------------------------------------------------------------------
+
+# ID prefix -> home document (the only doc where the prefix is *defined*).
+HOME_DOCS = {
+    "REQ": "02-requirements.md",
+    "OQ": "02-requirements.md",
+    "DEF": "03-data-model.md",
+    "WP": "04-mutations.md",
+    "RP": "05-queries.md",
+    "CN": "06-consistency-durability.md",
+    "INV": "07-invariants.md",
+    "LIV": "08-liveness.md",
+    "FM": "09-failure-model.md",
+    "RS": "10-retention-space.md",
+    "PF": "11-performance.md",
+    "SLI": "11-performance.md",
+    "HZ": "11-performance.md",
+    "OB": "12-observability.md",
+    "CT": "13-conformance-tdd.md",
+    "MG": "13-conformance-tdd.md",
+    "HC": "13-conformance-tdd.md",
+    "GAP": "13-conformance-tdd.md",
+    "IB": "14-interface-binding.md",
+    "G": "01-overview.md",
+    "NG": "01-overview.md",
+}
+PARAM_HOME = "15-parameters.md"       # P-* registry
+WPARAM_HOME = "11-performance.md"     # W-* workload table
+ADR_DIR = "decisions"
+ADR_LOG_DOC = "README.md"             # holds the decision-log table
+ADR_STATUSES = ("Accepted (historical)", "Proposed", "Accepted", "Superseded")
+
+MUTABLE_DOCS = {"13-conformance-tdd.md", "15-parameters.md"}
+MATRIX_DOC = "13-conformance-tdd.md"
+REQ_MATRIX_HEADING = "Requirements"
+PROP_MATRIX_HEADING = "Properties"
+PROP_MATRIX_PREFIXES = ("INV", "LIV", "FM", "SLI")
+
+# Goals/non-goals are top-level statements; references flow *from* them, so they
+# are exempt from the orphan check.
+ORPHAN_EXEMPT_PREFIXES = {"G", "NG"}
+
+# impl-leakage: normative core docs only (14 binds the concrete surface by design;
+# 13/15 are mutable status docs; decisions/ exempt per the skill).
+LEAKAGE_DOCS = [
+    "01-overview.md", "02-requirements.md", "03-data-model.md", "04-mutations.md",
+    "05-queries.md", "06-consistency-durability.md", "07-invariants.md",
+    "08-liveness.md", "09-failure-model.md", "10-retention-space.md",
+    "11-performance.md", "12-observability.md",
+]
+LEAKAGE_TERMS = [
+    r"\btokio\b", r"\brayon\b", r"\bpolars\b", r"\brusqlite\b", r"\bsqlite\b",
+    r"\breqwest\b", r"\blibp2p\b", r"\bflatbuffers?\b", r"\bprotobuf\b",
+    r"\bprost\b", r"\baxum\b", r"\bscopeguard\b", r"\bmimalloc\b", r"\bquic\b",
+    r"\bgossipsub\b", r"\bparquet\b", r"\bcargo\b", r"\bclippy\b", r"\brustc?\b",
+    r"\bMutex\b", r"\bBTreeSet\b", r"\bsrc/", r"\.rs\b", r"\bworkdir\b",
+]
+# The terminology cross-reference table in 03 deliberately maps codebase terms.
+LEAKAGE_EXEMPT_SECTIONS = {"Terminology cross-reference"}
+
+BARE_CONST_DOCS = LEAKAGE_DOCS  # same scope; tables and exempt sections skipped
+BARE_CONST_RE = re.compile(
+    r"(?<![\w./-])\d[\d\s]*(?:\.\d+)?\s?(?:ms|s\b|h\b|MiB|KiB|GiB|MB|KB|GB|%)"
+)
+BARE_CONST_EXEMPT_SECTIONS = {
+    "Open questions", "Explicitly unspecified", "Benchmark numbers on record",
+    "Terminology cross-reference",
+}
+
+FRESHNESS_BASELINE_RE = re.compile(r"baseline(?:\s+commit)?\s+`([0-9a-f]{7,40})`")
+AS_OF_RE = re.compile(r"[Aa]s of:?\s*\**\s*(\d{4}-\d{2}-\d{2})")
+
+ALL_PREFIXES = sorted(HOME_DOCS, key=len, reverse=True)
+# ADR is referenced like any ID but defined by files in decisions/, not a home doc.
+ID_RE = re.compile(
+    r"\b(" + "|".join(ALL_PREFIXES + ["ADR"]) + r")-(\d+)"
+    r"((?:/\d+)+)?"                      # slash lists: INV-20/21/25
+    r"(?:\.\.(?:(?:" + "|".join(ALL_PREFIXES) + r")-)?(\d+))?"  # ranges: CT-2..9
+)
+PARAM_RE = re.compile(r"\bP-[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)+\b")
+PARAM_CODE_RE = re.compile(r"\bP_[A-Z][A-Z0-9_]+\b")
+WPARAM_RE = re.compile(r"\bW-[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)*\b")
+STRONG_DEF_RE = re.compile(r"\*\*([A-Z]+)-(\d+)\s+—")
+HEADING_DEF_RE = re.compile(r"^#{1,6}\s+([A-Z]+)-(\d+)\s+—\s+(.*)$")
+ROW_DEF_RE = re.compile(r"^\|\s*([A-Z]+)-(\d+)\b")
+LINK_RE = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
+RFC_TAG_RE = re.compile(r"\[(MUST|MUST NOT|SHOULD|SHOULD NOT|MAY)(?:\s*—[^\]]*)?\]")
+SCOPE_TAG_RE = re.compile(r"\[(state|transition|response|recovery)\]")
+BAND_LINE_RE = re.compile(r"^(Home doc for|Bands?:)|\bBands?:")
+
+CHECKS = {
+    # name: (severity, description)
+    "id-undefined": ("E", "every referenced ID is defined in its home doc"),
+    "id-duplicate": ("E", "no ID has two strong-form definitions"),
+    "param-undefined": ("E", "every P-*/W-* symbol has a registry row"),
+    "link-missing-file": ("E", "relative links resolve"),
+    "link-missing-anchor": ("E", "#fragments name a real heading"),
+    "doc-unlisted": ("E", "every spec doc is in the README document map"),
+    "doc-missing": ("E", "every document-map entry exists"),
+    "adr-undefined": ("E", "every referenced ADR-n has a file"),
+    "id-orphan": ("W", "every defined ID is referenced beyond its definition"),
+    "param-unused": ("W", "every registry row is referenced elsewhere"),
+    "trace-missing": ("E", "every REQ / INV,LIV,FM,SLI has a matrix row"),
+    "trace-unknown": ("E", "matrix rows name only defined IDs"),
+    "inv-check-unknown": ("E", "invariant Check: names existing CT classes"),
+    "gate-threshold-literal": ("E", "MG thresholds are P-* symbols"),
+    "gate-no-capability": ("E", "every MG names an HC"),
+    "gate-unknown-class": ("E", "CT named by a gate exists"),
+    "hc-orphan": ("W", "every HC is needed by a CT or MG"),
+    "ct-unbuildable": ("W", "no CT with only-U capabilities claims C coverage"),
+    "adr-missing-file": ("E", "every log row has a file"),
+    "adr-missing-row": ("E", "every ADR file is in the README log"),
+    "adr-status-mismatch": ("E", "log status matches the file Status: line"),
+    "adr-id-mismatch": ("E", "filename, heading and log row agree"),
+    "adr-bad-status": ("E", "ADR status is from the allowed set"),
+    "adr-log-order": ("W", "accepted log rows ascend"),
+    "adr-title-drift": ("I", "log title matches the ADR heading"),
+    "req-missing-tag": ("E", "every REQ carries an RFC 2119 tag"),
+    "req-missing-acceptance": ("E", "every REQ has Acceptance:"),
+    "inv-missing-scope": ("E", "every INV carries a scope tag"),
+    "inv-missing-check": ("E", "every INV has Check:"),
+    "param-bare-constant": ("W", "no bare dimensioned literal in normative prose"),
+    "impl-leakage": ("W", "no implementation names in core normative docs"),
+    "heading-duplicate": ("W", "heading slugs unique per file"),
+    "warn-unratified": ("W", "every ⚠ routes to an ADR/OQ/GAP/registry row"),
+    "stale-matrix": ("W", "status doc as-of date not older than normative docs"),
+    "date-inconsistent": ("W", "one as-of date per mutable doc"),
+    "stale-baseline": ("W", "pinned baseline commit exists"),
+}
+
+# ----------------------------------------------------------------------------
+
+
+class Finding:
+    def __init__(self, check, path, line, msg):
+        self.check = check
+        self.sev = CHECKS[check][0]
+        self.path = path
+        self.line = line
+        self.msg = msg
+
+
+def strip_fences(lines):
+    out, fenced = [], False
+    for ln in lines:
+        if ln.lstrip().startswith("```"):
+            fenced = not fenced
+            out.append("")
+            continue
+        out.append("" if fenced else ln)
+    return out
+
+
+def slugify(text):
+    text = re.sub(r"[`*_\[\]()§]", "", text).strip().lower()
+    text = re.sub(r"[^\w\s-]", "", text)
+    return re.sub(r"[\s]+", "-", text)
+
+
+def expand_ids(text):
+    """Yield (prefix, num, hard) for every ID reference, expanding shorthand."""
+    for m in ID_RE.finditer(text):
+        prefix, first = m.group(1), int(m.group(2))
+        yield prefix, first, True
+        if m.group(3):
+            for part in m.group(3).strip("/").split("/"):
+                yield prefix, int(part), True
+        if m.group(4):
+            last = int(m.group(4))
+            yield prefix, last, True
+            for n in range(first + 1, last):
+                yield prefix, n, False  # interior of a range: soft
+
+
+class Suite:
+    def __init__(self, root):
+        self.root = root
+        self.files = {}  # rel path -> list of lines
+        for dirpath, _dirs, names in os.walk(root):
+            if os.path.basename(dirpath) == "tools":
+                continue
+            for name in sorted(names):
+                if name.endswith(".md"):
+                    rel = os.path.relpath(os.path.join(dirpath, name), root)
+                    with open(os.path.join(dirpath, name), encoding="utf-8") as fh:
+                        self.files[rel] = fh.read().splitlines()
+        self.findings = []
+        self.defs = {}      # (prefix, num) -> (path, line)
+        self.refs = defaultdict(list)   # (prefix, num) -> [(path, line, hard)]
+        self.params = {}    # symbol -> (path, line)  (P-* and W-* rows)
+        self.param_refs = defaultdict(list)
+        self.adr_files = {}  # num -> (relpath, heading_title, status, line)
+        self.adr_rows = {}   # num -> (title, status, line)
+
+    def add(self, check, path, line, msg):
+        self.findings.append(Finding(check, path, line, msg))
+
+    # -- collection ----------------------------------------------------------
+
+    def collect(self):
+        for path, lines in self.files.items():
+            clean = strip_fences(lines)
+            in_dec = path.startswith(ADR_DIR + os.sep) or path.startswith(ADR_DIR + "/")
+            # definitions (home docs and ADR files only)
+            for i, ln in enumerate(clean, 1):
+                if in_dec:
+                    m = HEADING_DEF_RE.match(ln)
+                    if m and m.group(1) == "ADR":
+                        num = int(m.group(2))
+                        status = self._adr_status(lines)
+                        self.adr_files[num] = (path, m.group(3).strip(), status, i)
+                    continue
+                for m in STRONG_DEF_RE.finditer(ln):
+                    self._maybe_define(m.group(1), int(m.group(2)), path, i, strong=True)
+                m = HEADING_DEF_RE.match(ln)
+                if m:
+                    self._maybe_define(m.group(1), int(m.group(2)), path, i, strong=True)
+                m = ROW_DEF_RE.match(ln)
+                if m:
+                    self._maybe_define(m.group(1), int(m.group(2)), path, i, strong=False)
+                if path == PARAM_HOME:
+                    pm = re.match(r"^\|\s*(P-[A-Z0-9-]+)\s*\|", ln)
+                    if pm and pm.group(1) not in self.params:
+                        self.params[pm.group(1)] = (path, i)
+                if path == WPARAM_HOME:
+                    wm = re.match(r"^\|\s*(W-[A-Z0-9-]+)\s*\|", ln)
+                    if wm and wm.group(1) not in self.params:
+                        self.params[wm.group(1)] = (path, i)
+            # references (fences NOT stripped: pseudocode refs are real).
+            # The header block (everything before the second blank line) holds
+            # the band declarations, which legitimately span unassigned numbers
+            # — skip ID extraction there.
+            blanks = 0
+            header_end = 0
+            for i, ln in enumerate(lines, 1):
+                if not ln.strip():
+                    blanks += 1
+                    if blanks == 2:
+                        header_end = i
+                        break
+            for i, ln in enumerate(lines, 1):
+                if i <= header_end and not in_dec:
+                    continue
+                if BAND_LINE_RE.search(ln) and "|" not in ln:
+                    continue  # band declarations span unassigned numbers
+                for prefix, num, hard in expand_ids(ln):
+                    self.refs[(prefix, num)].append((path, i, hard))
+                for pm in PARAM_RE.finditer(ln):
+                    self.param_refs[pm.group(0)].append((path, i))
+                for pm in PARAM_CODE_RE.finditer(ln):
+                    self.param_refs[pm.group(0).replace("_", "-")].append((path, i))
+                for wm in WPARAM_RE.finditer(ln):
+                    self.param_refs[wm.group(0)].append((path, i))
+
+    def _maybe_define(self, prefix, num, path, line, strong):
+        if prefix not in HOME_DOCS or HOME_DOCS[prefix] != path:
+            return
+        key = (prefix, num)
+        if key in self.defs:
+            if strong and self.defs[key][2]:
+                self.add("id-duplicate", path, line,
+                         f"{prefix}-{num} already defined at "
+                         f"{self.defs[key][0]}:{self.defs[key][1]}")
+            return
+        self.defs[key] = (path, line, strong)
+
+    @staticmethod
+    def _adr_status(lines):
+        for ln in lines:
+            m = re.match(r"^Status:\s*(.+?)\s*$", ln)
+            if m:
+                return m.group(1)
+        return None
+
+    # -- checks --------------------------------------------------------------
+
+    def check_reference_integrity(self):
+        for (prefix, num), sites in sorted(self.refs.items()):
+            if prefix == "ADR":
+                continue
+            if (prefix, num) not in self.defs:
+                hard_sites = [s for s in sites if s[2]]
+                if hard_sites:
+                    p, l, _ = hard_sites[0]
+                    self.add("id-undefined", p, l,
+                             f"{prefix}-{num} is referenced but not defined in "
+                             f"{HOME_DOCS[prefix]}")
+        for (prefix, num), sites in sorted(self.refs.items()):
+            if prefix == "ADR" and num not in self.adr_files:
+                p, l, _ = sites[0]
+                self.add("adr-undefined", p, l, f"ADR-{num} has no file in {ADR_DIR}/")
+        for sym, sites in sorted(self.param_refs.items()):
+            if sym not in self.params:
+                p, l = sites[0]
+                home = PARAM_HOME if sym.startswith("P-") else WPARAM_HOME
+                self.add("param-undefined", p, l, f"{sym} has no row in {home}")
+
+    def check_links(self):
+        for path, lines in self.files.items():
+            base = os.path.dirname(os.path.join(self.root, path))
+            for i, ln in enumerate(lines, 1):
+                for m in LINK_RE.finditer(ln):
+                    target = m.group(1)
+                    if target.startswith(("http://", "https://", "mailto:")):
+                        continue
+                    frag = None
+                    if "#" in target:
+                        target, frag = target.split("#", 1)
+                    tpath = os.path.normpath(os.path.join(base, target)) if target \
+                        else os.path.join(self.root, path)
+                    if target and not os.path.exists(tpath):
+                        self.add("link-missing-file", path, i,
+                                 f"link target does not exist: {m.group(1)}")
+                        continue
+                    if frag:
+                        rel = os.path.relpath(tpath, self.root)
+                        doc = self.files.get(rel.replace(os.sep, "/"))
+                        if doc is None:
+                            continue
+                        slugs = {slugify(h.lstrip("#").strip())
+                                 for h in doc if h.startswith("#")}
+                        if frag not in slugs:
+                            self.add("link-missing-anchor", path, i,
+                                     f"#{frag} is not a heading in {rel}")
+
+    def check_doc_map(self):
+        readme = self.files.get("README.md", [])
+        listed = set()
+        for ln in readme:
+            for m in LINK_RE.finditer(ln):
+                t = m.group(1).split("#")[0]
+                if t.endswith(".md"):
+                    listed.add(t)
+        for ln in readme:
+            if re.search(r"^\|\s*decisions/", ln):
+                listed.add(ADR_DIR)
+        for path in self.files:
+            p = path.replace(os.sep, "/")
+            if p == "README.md":
+                continue
+            if p.startswith("decisions/"):
+                if ADR_DIR not in listed and p not in listed:
+                    self.add("doc-unlisted", "README.md", 1,
+                             f"{p} unreachable: decisions/ not in the document map")
+                continue
+            if p not in listed:
+                self.add("doc-unlisted", "README.md", 1,
+                         f"{p} is not in the README document map")
+        for t in listed:
+            if t.endswith(".md") and t.replace("/", os.sep) not in self.files:
+                self.add("doc-missing", "README.md", 1,
+                         f"document map names a missing file: {t}")
+
+    def check_dead_weight(self):
+        closed_re = re.compile(r"^#{1,6}\s+.*(closed|resolved|retired)", re.I)
+        for (prefix, num), (path, line, _s) in sorted(self.defs.items()):
+            if prefix in ORPHAN_EXEMPT_PREFIXES:
+                continue
+            ext = [s for s in self.refs.get((prefix, num), [])
+                   if not (s[0] == path and s[1] == line)]
+            if not ext:
+                # exempt closed-register entries
+                section = self._section_of(path, line)
+                if section and closed_re.match("# " + section):
+                    continue
+                self.add("id-orphan", path, line,
+                         f"{prefix}-{num} is defined but referenced nowhere else")
+        for sym, (path, line) in sorted(self.params.items()):
+            ext = [s for s in self.param_refs.get(sym, [])
+                   if not (s[0] == path and s[1] == line)]
+            if not ext:
+                self.add("param-unused", path, line,
+                         f"{sym} has a registry row but is used nowhere else")
+
+    def _section_of(self, path, line):
+        lines = self.files[path]
+        for i in range(min(line, len(lines)) - 1, -1, -1):
+            if lines[i].startswith("#"):
+                return lines[i].lstrip("#").strip()
+        return None
+
+    def _matrix_first_cells(self, heading):
+        lines = self.files.get(MATRIX_DOC, [])
+        cells, active = [], False
+        for i, ln in enumerate(lines, 1):
+            h = re.match(r"^(#{2,6})\s+(.*)$", ln)
+            if h:
+                active = h.group(2).strip() == heading
+                continue
+            if active:
+                m = re.match(r"^\|\s*([^|]+?)\s*\|", ln)
+                if m and m.group(1) not in ("ID", ":---", "---") \
+                        and not set(m.group(1)) <= set(":- "):
+                    cells.append((m.group(1), i))
+        return cells
+
+    def check_traceability(self):
+        covered = defaultdict(set)
+        for heading in (REQ_MATRIX_HEADING, PROP_MATRIX_HEADING):
+            for cell, line in self._matrix_first_cells(heading):
+                for prefix, num, _hard in expand_ids(cell):
+                    covered[prefix].add(num)
+                    if (prefix, num) not in self.defs:
+                        self.add("trace-unknown", MATRIX_DOC, line,
+                                 f"matrix row names undefined {prefix}-{num}")
+        for (prefix, num) in sorted(self.defs):
+            if prefix == "REQ" and num not in covered["REQ"]:
+                self.add("trace-missing", MATRIX_DOC, 1,
+                         f"REQ-{num} has no row in the {REQ_MATRIX_HEADING} matrix")
+            if prefix in PROP_MATRIX_PREFIXES and num not in covered[prefix]:
+                self.add("trace-missing", MATRIX_DOC, 1,
+                         f"{prefix}-{num} has no row in the "
+                         f"{PROP_MATRIX_HEADING} matrix")
+
+    def check_inv_shape(self):
+        lines = self.files.get(HOME_DOCS["INV"], [])
+        clean = strip_fences(lines)
+        entries = [(i, m) for i, ln in enumerate(clean, 1)
+                   for m in [STRONG_DEF_RE.search(ln)] if m and m.group(1) == "INV"]
+        for idx, (i, m) in enumerate(entries):
+            end = entries[idx + 1][0] - 1 if idx + 1 < len(entries) else len(clean)
+            block = clean[i - 1:end]
+            if not SCOPE_TAG_RE.search(block[0]):
+                self.add("inv-missing-scope", HOME_DOCS["INV"], i,
+                         f"INV-{m.group(2)} has no [state|transition|response|"
+                         f"recovery] tag on its definition line")
+            if not any("*Check:*" in ln for ln in block):
+                self.add("inv-missing-check", HOME_DOCS["INV"], i,
+                         f"INV-{m.group(2)} names no check strategy")
+            for ln_off, ln in enumerate(block):
+                if "*Check:*" in ln:
+                    cts = [n for p, n, _ in expand_ids(ln) if p == "CT"]
+                    for n in cts:
+                        if ("CT", n) not in self.defs:
+                            self.add("inv-check-unknown", HOME_DOCS["INV"],
+                                     i + ln_off,
+                                     f"INV-{m.group(2)} Check: names CT-{n}, "
+                                     f"which is not in the taxonomy")
+
+    def check_req_shape(self):
+        lines = strip_fences(self.files.get(HOME_DOCS["REQ"], []))
+        entries = [(i, m) for i, ln in enumerate(lines, 1)
+                   for m in [STRONG_DEF_RE.search(ln)] if m and m.group(1) == "REQ"]
+        for idx, (i, m) in enumerate(entries):
+            end = entries[idx + 1][0] - 1 if idx + 1 < len(entries) else len(lines)
+            block = lines[i - 1:end]
+            if not RFC_TAG_RE.search(" ".join(block[:3])):
+                self.add("req-missing-tag", HOME_DOCS["REQ"], i,
+                         f"REQ-{m.group(2)} has no RFC 2119 tag")
+            if not any("*Acceptance:*" in ln for ln in block):
+                self.add("req-missing-acceptance", HOME_DOCS["REQ"], i,
+                         f"REQ-{m.group(2)} has no *Acceptance:* criteria")
+
+    def check_gates(self):
+        lines = self.files.get(MATRIX_DOC, [])
+        hc_status = {}
+        for i, ln in enumerate(lines, 1):
+            m = re.match(r"^\|\s*HC-(\d+)\s*\|[^|]*\|[^|]*\|\s*\**([CPU])\**\s*\|", ln)
+            if m:
+                hc_status[int(m.group(1))] = m.group(2)
+        needed_hc = set()
+        for i, ln in enumerate(lines, 1):
+            m = re.match(r"^\|\s*MG-(\d+)\s*\|", ln)
+            if not m:
+                continue
+            cells = [c.strip() for c in ln.strip("|").split("|")]
+            gate_text = " ".join(cells)
+            threshold = cells[2] if len(cells) > 2 else ""
+            enforced = cells[4] if len(cells) > 4 else ""
+            if not PARAM_RE.search(threshold):
+                self.add("gate-threshold-literal", MATRIX_DOC, i,
+                         f"MG-{m.group(1)} threshold is not a P-* symbol: "
+                         f"'{threshold}' — register it in {PARAM_HOME}")
+            hcs = [n for p, n, _ in expand_ids(enforced) if p == "HC"]
+            if not hcs:
+                self.add("gate-no-capability", MATRIX_DOC, i,
+                         f"MG-{m.group(1)} names no HC-n in its 'enforced by' cell")
+            needed_hc.update(hcs)
+            for p, n, _ in expand_ids(gate_text):
+                if p == "CT" and ("CT", n) not in self.defs:
+                    self.add("gate-unknown-class", MATRIX_DOC, i,
+                             f"MG-{m.group(1)} names CT-{n}, not in the taxonomy")
+        ct_needs = {}
+        for i, ln in enumerate(lines, 1):
+            m = re.match(r"^\|\s*CT-(\d+)\s*\|", ln)
+            if m and "Needs" not in ln:
+                cells = [c.strip() for c in ln.strip("|").split("|")]
+                if len(cells) >= 4:
+                    ct_needs[int(m.group(1))] = \
+                        [n for p, n, _ in expand_ids(cells[3]) if p == "HC"]
+                    needed_hc.update(ct_needs[int(m.group(1))])
+        for num in sorted(hc_status):
+            if num not in needed_hc:
+                p, l, _ = self.defs.get(("HC", num), (MATRIX_DOC, 1, False))
+                self.add("hc-orphan", p, l,
+                         f"HC-{num} is needed by no CT class or merge gate")
+        # ct-unbuildable: a CT with only-U capabilities while a matrix row it owns
+        # claims status C
+        c_rows = set()
+        for heading in (REQ_MATRIX_HEADING, PROP_MATRIX_HEADING):
+            for cell, line in self._matrix_first_cells(heading):
+                row = self.files[MATRIX_DOC][line - 1]
+                cells = [c.strip() for c in row.strip("|").split("|")]
+                if len(cells) >= 3 and cells[2].startswith("C"):
+                    for p, n, _ in expand_ids(cells[1]):
+                        if p == "CT":
+                            c_rows.add(n)
+        for ct, needs in sorted(ct_needs.items()):
+            if ct in c_rows and needs and all(
+                    hc_status.get(h, "U") == "U" for h in needs):
+                self.add("ct-unbuildable", MATRIX_DOC, 1,
+                         f"CT-{ct} claims C coverage but every capability it "
+                         f"needs is status U")
+
+    def check_adr_log(self):
+        readme = self.files.get(ADR_LOG_DOC, [])
+        row_re = re.compile(
+            r"^\|\s*\[ADR-(\d+)\]\(([^)]+)\)\s*\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|")
+        prev_accepted = 0
+        for i, ln in enumerate(readme, 1):
+            m = row_re.match(ln)
+            if not m:
+                if re.match(r"^\|\s*ADR-\d+\s*\|", ln):
+                    n = int(re.match(r"^\|\s*ADR-(\d+)", ln).group(1))
+                    self.adr_rows[n] = (None, None, i)  # unlinked → external
+                continue
+            num, path, title, status = (int(m.group(1)), m.group(2),
+                                        m.group(3), re.sub(r"\*", "", m.group(4)))
+            self.adr_rows[num] = (title, status.strip(), i)
+            fpath = os.path.normpath(os.path.join(self.root, path))
+            if not os.path.exists(fpath):
+                self.add("adr-missing-file", ADR_LOG_DOC, i,
+                         f"ADR-{num} log row links a missing file: {path}")
+                continue
+            fnum_m = re.search(r"ADR-(\d+)", os.path.basename(path))
+            if fnum_m and int(fnum_m.group(1)) != num:
+                self.add("adr-id-mismatch", ADR_LOG_DOC, i,
+                         f"log row ADR-{num} links file named ADR-{fnum_m.group(1)}")
+            info = self.adr_files.get(num)
+            if info:
+                fpath_rel, heading, fstatus, fline = info
+                if fstatus is None or not fstatus.startswith(ADR_STATUSES):
+                    self.add("adr-bad-status", fpath_rel, 1,
+                             f"ADR-{num} Status: line missing or not in "
+                             f"{ADR_STATUSES}")
+                elif self._norm_status(fstatus) != self._norm_status(status):
+                    self.add("adr-status-mismatch", ADR_LOG_DOC, i,
+                             f"ADR-{num}: log says '{status.strip()}', file says "
+                             f"'{fstatus}'")
+                # date agreement, when both carry one
+                d_log = re.search(r"\d{4}-\d{2}-\d{2}", status)
+                d_file = re.search(r"\d{4}-\d{2}-\d{2}", fstatus or "")
+                if d_log and d_file and d_log.group(0) != d_file.group(0):
+                    self.add("adr-status-mismatch", ADR_LOG_DOC, i,
+                             f"ADR-{num}: log date {d_log.group(0)} != file date "
+                             f"{d_file.group(0)}")
+                t_log = re.sub(r"\s*\([^)]*\)", "", title).strip().lower()
+                t_file = re.sub(r"\s*\([^)]*\)", "", heading).strip().lower()
+                if t_log != t_file:
+                    self.add("adr-title-drift", ADR_LOG_DOC, i,
+                             f"ADR-{num} log title '{title}' vs heading '{heading}'")
+                if "Accepted" in (fstatus or ""):
+                    if num < prev_accepted:
+                        self.add("adr-log-order", ADR_LOG_DOC, i,
+                                 f"accepted ADR-{num} listed after ADR-{prev_accepted}")
+                    prev_accepted = max(prev_accepted, num)
+        for num, (fpath_rel, _h, _s, _l) in sorted(self.adr_files.items()):
+            if num not in self.adr_rows:
+                self.add("adr-missing-row", fpath_rel, 1,
+                         f"ADR-{num} has a file but no row in the README decision log")
+
+    @staticmethod
+    def _norm_status(s):
+        s = re.sub(r"\s*\(\d{4}-\d{2}-\d{2}\)", "", s or "")
+        return s.strip().lower()
+
+    def check_normative_shape(self):
+        for path in BARE_CONST_DOCS:
+            lines = strip_fences(self.files.get(path, []))
+            for i, ln in enumerate(lines, 1):
+                if ln.lstrip().startswith("|") or ln.startswith("#"):
+                    continue
+                section = self._section_of(path, i) or ""
+                if any(s.lower() in section.lower()
+                       for s in BARE_CONST_EXEMPT_SECTIONS):
+                    continue
+                if BAND_LINE_RE.search(ln):
+                    continue
+                m = BARE_CONST_RE.search(ln)
+                if m:
+                    self.add("param-bare-constant", path, i,
+                             f"bare constant '{m.group(0).strip()}' in normative "
+                             f"prose — use a P-* symbol")
+        for path in LEAKAGE_DOCS:
+            lines = strip_fences(self.files.get(path, []))
+            for i, ln in enumerate(lines, 1):
+                section = self._section_of(path, i) or ""
+                if any(s.lower() in section.lower()
+                       for s in LEAKAGE_EXEMPT_SECTIONS):
+                    continue
+                for term in LEAKAGE_TERMS:
+                    m = re.search(term, ln, re.I)
+                    if m:
+                        self.add("impl-leakage", path, i,
+                                 f"implementation term '{m.group(0)}' in a "
+                                 f"normative core doc")
+        for path, lines in self.files.items():
+            seen = {}
+            for i, ln in enumerate(lines, 1):
+                if ln.startswith("#"):
+                    slug = slugify(ln.lstrip("#").strip())
+                    if slug in seen:
+                        self.add("heading-duplicate", path, i,
+                                 f"heading slug '{slug}' duplicates line {seen[slug]}")
+                    seen[slug] = i
+        self._check_warn_markers()
+
+    def _routed_params(self):
+        routed = set()
+        header_routes = False
+        lines = self.files.get(PARAM_HOME, [])
+        for ln in lines[:12]:
+            if re.search(r"ADR-\d+|ratif|proposed|draft", ln, re.I):
+                header_routes = True
+        for ln in lines:
+            m = re.match(r"^\|\s*((?:P|W)-[A-Z0-9-]+)\s*\|", ln)
+            if m and (header_routes
+                      or re.search(r"ADR-\d+|OQ-\d+|GAP-\d+|ratif|proposed|draft",
+                                   ln, re.I)):
+                routed.add(m.group(1))
+        return routed
+
+    def _check_warn_markers(self):
+        routed = self._routed_params()
+        route_re = re.compile(r"\b(ADR|OQ|GAP)-\d+\b")
+        for path, lines in self.files.items():
+            # README defines the marker; the registry routes via its header rule;
+            # decisions/ files ARE the ratification route.
+            if path == "README.md" or path == PARAM_HOME \
+                    or path.replace(os.sep, "/").startswith(ADR_DIR + "/"):
+                continue
+            clean = strip_fences(lines)
+            i = 0
+            while i < len(clean):
+                ln = clean[i]
+                if "⚠" not in ln:
+                    i += 1
+                    continue
+                if ln.lstrip().startswith("|"):
+                    row = ln
+                    nxt = clean[i + 1] if i + 1 < len(clean) else ""
+                    if set(re.sub(r"[|\s:⚠-]", "", row)) == set() or "---" in row \
+                            or re.match(r"^\|[\s:|-]+\|?$", nxt):
+                        i += 1
+                        continue  # separator, or column-header row (⚠ is a legend)
+                    ok = bool(route_re.search(row)) or any(
+                        p in routed for p in PARAM_RE.findall(row))
+                    if not ok:
+                        self.add("warn-unratified", path, i + 1,
+                                 "⚠ in this row routes to no ADR/OQ/GAP or "
+                                 "routed parameter")
+                    i += 1
+                    continue
+                # prose: search the enclosing paragraph
+                start = i
+                while start > 0 and clean[start - 1].strip():
+                    start -= 1
+                end = i
+                while end + 1 < len(clean) and clean[end + 1].strip():
+                    end += 1
+                para = " ".join(clean[start:end + 1])
+                ok = bool(route_re.search(para)) or any(
+                    p in routed for p in PARAM_RE.findall(para))
+                if not ok:
+                    self.add("warn-unratified", path, i + 1,
+                             "⚠ in this paragraph routes to no ADR/OQ/GAP or "
+                             "routed parameter")
+                i = end + 1
+
+    def check_freshness(self):
+        as_of = {}
+        for doc in MUTABLE_DOCS:
+            dates = set()
+            for ln in self.files.get(doc, []):
+                for m in AS_OF_RE.finditer(ln):
+                    dates.add(m.group(1))
+                for m in re.finditer(r"\(as of (\d{4}-\d{2}-\d{2})\)", ln):
+                    dates.add(m.group(1))
+            if len(dates) > 1:
+                self.add("date-inconsistent", doc, 1,
+                         f"multiple as-of dates: {sorted(dates)}")
+            if dates:
+                as_of[doc] = max(dates)
+        baseline = None
+        for ln in self.files.get(MATRIX_DOC, []):
+            m = FRESHNESS_BASELINE_RE.search(ln)
+            if m:
+                baseline = m.group(1)
+                break
+        repo = os.path.dirname(os.path.abspath(self.root))
+
+        def git(*args):
+            try:
+                return subprocess.run(["git", "-C", repo, *args],
+                                      capture_output=True, text=True,
+                                      timeout=30).stdout.strip()
+            except Exception:
+                return ""
+
+        if baseline:
+            ok = subprocess.run(
+                ["git", "-C", repo, "cat-file", "-e", baseline + "^{commit}"],
+                capture_output=True).returncode == 0
+            if not ok:
+                self.add("stale-baseline", MATRIX_DOC, 1,
+                         f"baseline commit {baseline} not found in repository "
+                         f"history")
+        bar = as_of.get(MATRIX_DOC)
+        if bar and git("rev-parse", "--is-inside-work-tree") == "true":
+            dirty = set(git("status", "--porcelain", "--", self.root).splitlines())
+            dirty_docs = {re.sub(r"^..\s+", "", d).split("/")[-1] for d in dirty}
+            status_dirty = any(d in dirty_docs for d in MUTABLE_DOCS)
+            for path in self.files:
+                if path in MUTABLE_DOCS or path == "README.md" \
+                        or path.startswith("decisions"):
+                    continue
+                last = git("log", "-1", "--format=%as", "--",
+                           os.path.join(self.root, path))
+                if last and last > bar:
+                    self.add("stale-matrix", path, 1,
+                             f"last commit {last} is newer than {MATRIX_DOC}'s "
+                             f"as-of date {bar} — update the matrix in the same "
+                             f"change")
+                if os.path.basename(path) in dirty_docs and not status_dirty \
+                        and last:
+                    self.add("stale-matrix", path, 1,
+                             "normative doc is dirty while the status doc is "
+                             "clean — they must change together")
+
+    # -- driver --------------------------------------------------------------
+
+    def run(self, only=None):
+        self.collect()
+        groups = [
+            ("id-undefined", self.check_reference_integrity),
+            ("link", self.check_links),
+            ("doc", self.check_doc_map),
+            ("orphan", self.check_dead_weight),
+            ("trace", self.check_traceability),
+            ("inv", self.check_inv_shape),
+            ("req", self.check_req_shape),
+            ("gate", self.check_gates),
+            ("adr", self.check_adr_log),
+            ("shape", self.check_normative_shape),
+            ("fresh", self.check_freshness),
+        ]
+        for _name, fn in groups:
+            fn()
+        if only:
+            self.findings = [f for f in self.findings if f.check in only]
+
+
+def load_ignores(root, no_ignore):
+    path = os.path.join(root, "tools", "check_spec.ignore")
+    rules = []
+    if no_ignore or not os.path.exists(path):
+        return rules
+    with open(path, encoding="utf-8") as fh:
+        for ln in fh:
+            ln = ln.strip()
+            if not ln or ln.startswith("#"):
+                continue
+            parts = [p.strip() for p in ln.split("|")]
+            if len(parts) == 3:
+                rules.append(parts)
+    return rules
+
+
+def main(argv):
+    args, root, fmt, min_sev, only, strict, no_ignore = argv[1:], "spec", "text", \
+        None, None, False, False
+    it = iter(args)
+    for a in it:
+        if a == "--format":
+            fmt = next(it, "text")
+        elif a == "--severity":
+            min_sev = next(it, None)
+        elif a == "--only":
+            only = set(next(it, "").split(","))
+        elif a == "--strict":
+            strict = True
+        elif a == "--no-ignore":
+            no_ignore = True
+        elif a == "--list-checks":
+            for name, (sev, desc) in CHECKS.items():
+                print(f"{sev}  {name:24} {desc}")
+            return 0
+        elif a.startswith("--"):
+            print(f"unknown option {a}", file=sys.stderr)
+            return 2
+        else:
+            root = a
+    if not os.path.isdir(root):
+        print(f"not a directory: {root}", file=sys.stderr)
+        return 2
+    if only and not only <= set(CHECKS):
+        print(f"unknown checks: {sorted(only - set(CHECKS))}", file=sys.stderr)
+        return 2
+
+    suite = Suite(root)
+    suite.run(only)
+
+    ignores = load_ignores(root, no_ignore)
+    kept = []
+    for f in suite.findings:
+        skip = False
+        for check, glob, msg_re in ignores:
+            import fnmatch
+            if f.check == check and fnmatch.fnmatch(f.path, glob) \
+                    and re.search(msg_re, f.msg):
+                skip = True
+                break
+        if not skip:
+            kept.append(f)
+    order = {"E": 0, "W": 1, "I": 2}
+    if min_sev:
+        kept = [f for f in kept if order[f.sev] <= order.get(min_sev, 2)]
+    kept.sort(key=lambda f: (order[f.sev], f.path, f.line))
+
+    if fmt == "json":
+        print(json.dumps([vars(f) for f in kept], indent=2))
+    elif fmt == "github":
+        for f in kept:
+            kind = "error" if f.sev == "E" else "warning" if f.sev == "W" else "notice"
+            print(f"::{kind} file={root}/{f.path},line={f.line},"
+                  f"title={f.check}::{f.msg}")
+    else:
+        for f in kept:
+            print(f"[{f.sev}] {f.check}: {f.path}:{f.line}: {f.msg}")
+        counts = defaultdict(int)
+        for f in kept:
+            counts[f.sev] += 1
+        print(f"\n{len(suite.files)} files · "
+              f"{counts['E']} error(s), {counts['W']} warning(s), "
+              f"{counts['I']} note(s)")
+    errors = [f for f in kept if f.sev == "E" or strict]
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/src/controller/experimental_engine.rs
+++ b/src/controller/experimental_engine.rs
@@ -433,10 +433,22 @@ tables:
         .to_string();
         let path = chunk.path().to_str().unwrap();
 
-        let json = execute_query(&query, &test_schema(), (10, 12), path, OutputFormat::JsonLines)
-            .unwrap();
-        let arrow = execute_query(&query, &test_schema(), (10, 12), path, OutputFormat::ArrowIpc)
-            .unwrap();
+        let json = execute_query(
+            &query,
+            &test_schema(),
+            (10, 12),
+            path,
+            OutputFormat::JsonLines,
+        )
+        .unwrap();
+        let arrow = execute_query(
+            &query,
+            &test_schema(),
+            (10, 12),
+            path,
+            OutputFormat::ArrowIpc,
+        )
+        .unwrap();
 
         // Same block range reported, but Arrow IPC bytes are a distinct, non-JSON encoding.
         assert_eq!(arrow.last_block, json.last_block);


### PR DESCRIPTION
## What this is

A full behavioral specification of the worker, reverse-engineered from the implementation at `42d9aa1`, living in `spec/`. It states what the worker MUST do (implementation-free, RFC 2119), records *why* it is that way (19 ADRs backfilled from commit history + 3 proposed), and carries a conformance program: a reference model as test oracle, a test-class taxonomy, a dated traceability matrix, and a prioritized gap register.

Start at [`spec/README.md`](../blob/spec-suite/spec/README.md) — it holds the document map, ID conventions, and the decision log.

## Why it matters now

The gap register (`spec/13-conformance-tdd.md`) captures 26 verified deviations between current behavior and intent, including three P0s:

- **GAP-1** — the `--parallel-queries` cap is inert: the scope guard at `src/controller/worker.rs:120` is bound to `_` and drops immediately, so the limit never fires and `running_queries` always reads ~0. The effective concurrency ceiling is 64 (transport handlers), not the configured 20.
- **GAP-2** — a single malformed file URL in an assignment panics the whole worker (`src/storage/manager.rs:139`): remote-triggerable process death.
- **GAP-3** — no deletion floor: one empty/short assignment wipes the entire local store on the next reconciliation pass.

Each entry names the violated properties and the cheapest failing-test-first entry point.

## Self-checking

`spec/tools/check_spec.py` (stdlib-only Python) gates the suite's own consistency — dangling IDs, unregistered parameters, matrix holes, decision-log drift, implementation leakage. Every check was verified by fault injection (35/35). The new `spec` workflow runs it on PRs touching `spec/`; it is not wired into the Rust CI.

## What needs human decisions

- Three **Proposed** ADRs: deletion floor (ADR-17), bounded/validated assignment intake (ADR-18), and ratification of all ⚠ provisional targets (ADR-19).
- Six open questions in `spec/02-requirements.md`, sharpest being OQ-1: does the heartbeat's `missing_chunks` bit order match the scheduler's interpretation for suffix-forked chunks?

No production code is touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)