### PR TITLE
Close the two remaining P0 gaps: process termination and store wipe

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -75,7 +75,7 @@ jobs:
             features: ""
           - config: all-features
             features: "--all-features"
-    # Three test binaries over the same heavy dependency graph — see the `test` job.
+    # Four test binaries over the same heavy dependency graph — see the `test` job.
     env:
       CARGO_BUILD_JOBS: "2"
     steps:
@@ -112,12 +112,13 @@ jobs:
           cargo test ${{ matrix.features }} \
             --test e2e \
             --test query_surface \
-            --test query_concurrency
+            --test query_concurrency \
+            --test assignment_faults
       # A gap test stays ignored until its fix lands (MG-8: failing-test-first, never a
       # silent skip). Listing them keeps any quarantine visible in the job log.
       - name: List quarantined gap tests
         run: |
-          for t in e2e query_surface query_concurrency; do
+          for t in e2e query_surface query_concurrency assignment_faults; do
             cargo test ${{ matrix.features }} --test "$t" -- --ignored --list
           done
 

--- a/spec/02-requirements.md
+++ b/spec/02-requirements.md
@@ -122,7 +122,7 @@ exception. [Payload integrity after power loss is intent, currently violated: GA
 some committed prefix; no residue accumulates across repeated kills (RS-6).
 *Trace:* CN-3/4/5, INV-40..42, WP-15, WP-23.
 
-**REQ-24 — Hostile-input robustness.** [MUST — intent, currently violated: GAP-2, GAP-4]
+**REQ-24 — Hostile-input robustness.** [MUST — intent, currently violated: GAP-4]
 No input — query bytes, assignment document, origin payload, log request — may terminate
 the process, corrupt either store, or cause unbounded memory growth. Malformed input
 yields a typed error (queries) or a rejected-and-retried document (assignments), with an
@@ -131,13 +131,15 @@ alarm.
 run to completion with the process alive and both stores intact.
 *Trace:* ADR-18; FM-1, FM-10..23, INV-36.
 
-**REQ-25 — Bounded reconciliation blast radius.** [SHOULD — intent, currently violated: GAP-3]
+**REQ-25 — Bounded reconciliation blast radius.** [SHOULD]
 A single assignment application SHOULD NOT delete more than the P-DEL-FLOOR fraction of
-the store without an explicit operator override; a wipe-inducing assignment is held,
-alarmed, and re-evaluated on the next poll. ⚠ pending ADR-17.
+the store; a wipe-inducing assignment is held, alarmed, and re-evaluated on every pass.
+The hold is bounded: it lapses after P-DEL-HOLD-MAX, so a shrink the network keeps
+republishing is eventually obeyed and the held bytes stay accountable to RS-3. An
+operator override releases it sooner.
 *Acceptance:* publish an assignment dropping all chunks: the store retains its data, an
-alarm level is raised (OB-12), and a subsequent restoring assignment resumes normal
-reconciliation.
+alarm level is raised (OB-12), a subsequent restoring assignment resumes normal
+reconciliation, and — absent one — the eviction proceeds once P-DEL-HOLD-MAX elapses.
 *Trace:* ADR-17; WP-14, RS-5, FM-13.
 
 ## Explicitly unspecified

--- a/spec/08-liveness.md
+++ b/spec/08-liveness.md
@@ -47,9 +47,11 @@ GAP-8; OQ-6.]
 
 **LIV-4 — Eviction convergence.**
 *Pre:* `c ∈ A`, `c ∉ N`, last pin released; process alive.
-*Bound:* store namespace removal within P-EVICT-BOUND ⚠ of the pin release — without
-requiring any further input event. [Currently violated: eviction waits for the next
-loop wake-up, potentially forever — GAP-6.]
+*Bound:* store namespace removal within P-EVICT-BOUND ⚠ of the pin release, or within
+P-DEL-HOLD-MAX + P-EVICT-BOUND when REQ-25's deletion floor withholds the batch — in
+both cases without requiring any further input event. [Currently violated for the
+pin-release path: eviction waits for the next loop wake-up, potentially forever —
+GAP-6. The floor's hold has its own timer.]
 *Witness:* evicted-chunks counter advances (OB-4); stored-bytes gauge falls (OB-5).
 *Check:* CT-1, CT-3.
 

--- a/spec/09-failure-model.md
+++ b/spec/09-failure-model.md
@@ -15,7 +15,7 @@ Response verbs, used in every table:
 ## Global requirements
 
 **FM-1 — No externally-triggered termination.** [MUST — intent, currently violated:
-GAP-2] No content arriving from any actor — query bytes, assignment documents, origin
+GAP-4] No content arriving from any actor — query bytes, assignment documents, origin
 payloads, log requests, registry responses, schema manifests — may terminate,
 deadlock, or abort the process. The only sanctioned self-terminations: operator
 shutdown, startup refusal on identity mismatch (CN-9) or invalid adopted layout
@@ -38,7 +38,7 @@ budget → that operator (INV-35); one assignment document → intake of that do
 | # | Fault | Required response |
 |---|---|---|
 | FM-10 | network-state/assignment endpoint unreachable or slow | mask: retry per WP-1; previous assignment stays in force; alarm past P-STALL-MAX (LIV-13) |
-| FM-11 | document with malformed per-chunk entries (bad address, bad credential) | degrade: affected chunks fail per-chunk (WP-2); rest of the document applies; alarm. [Currently: process panic — GAP-2] |
+| FM-11 | document with malformed per-chunk entries (bad address, bad credential) | degrade: affected chunks fail per-chunk (WP-2); rest of the document applies; alarm |
 | FM-12 | document malformed as a whole, oversized, undecodable, or missing this worker | fail-safe + alarm: reject whole document (WP-2); keep prior assignment; keep serving. [Oversize unbounded today — GAP-4] |
 | FM-13 | equivocating/regressive document (wipes the store, flip-flops) | degrade + alarm: REQ-25 deletion floor holds data; application order is arrival order (NG2) — flip-flops churn but never corrupt |
 | FM-14 | stale document served long-term (worker dropped or endpoint frozen) | degrade + alarm: serve last-applied data honestly; assignment-age observable (OB-13) rises. [No age alarm exists today — GAP-23] |
@@ -80,7 +80,7 @@ budget → that operator (INV-35); one assignment document → intake of that do
 |---|---|---|
 | FM-50 | misconfiguration (unparseable addresses, missing required settings) | fail-safe: refuse startup with a diagnostic — never a half-configured worker |
 | FM-51 | second process, different identity, same store | fail-safe: refuse before mutating (CN-9). [Sweep-before-check today — GAP-16] |
-| FM-52 | chain-registry unreachable or erroring | degrade: serve with last-known allocations/epoch; alarm past P-STALL-MAX. [Startup registry error is fatal today — GAP-2 register entry] |
+| FM-52 | chain-registry unreachable or erroring | degrade: serve with last-known allocations/epoch; alarm past P-STALL-MAX |
 | FM-53 | schema-registry unreachable or malformed manifest | degrade: keep previously loaded schemas; dynamic-engine queries fail typed `server_error` until first load |
 | FM-54 | worker absent from the on-chain registry at startup | degrade by design: poll the registry and serve nothing until listed; the wait is a visible lifecycle phase (OB-10) with an alarm past P-STALL-MAX (OB-12). [The wait is externally invisible today — GAP-28] |
 | FM-55 | worker clock skewed beyond P-TS-WINDOW tolerance (drift, operator error) | degrade + alarm: freshness rejections surface as `server_error`, never `bad_request` (RP-20 freshness verdict — a stale sender and own skew are indistinguishable here, ADR-20); rejection rate and skew estimate observable (OB-15); alarm past P-SKEW-ALARM. [Misclassified and invisible today — GAP-33] |

--- a/spec/10-retention-space.md
+++ b/spec/10-retention-space.md
@@ -16,15 +16,19 @@ policy table:
 
 **RS-2 — Availability floor.** [MUST] Eviction never removes: desired chunks, pinned
 chunks (whatever the assignment says), or — per REQ-25 — more than the P-DEL-FLOOR
-fraction of the store per application without operator override ⚠ (ADR-17). Precedence:
+fraction of the store per application, until the hold lapses at P-DEL-HOLD-MAX or an
+operator override releases it (ADR-17). Precedence:
 pin > assignment (a pinned undesired chunk stays until released; ADR-16's
 never-interrupt rule is the same precedence applied to application).
 
 **RS-3 — Excess bound (amplification).** [MUST] At every instant,
-`store bytes ≤ live bytes + P-DL-CONC × W-CHUNK-BYTES-MAX + R + G`, where live = bytes
-of desired∪pinned committed chunks, the second term bounds in-flight fetch space, `R` =
-unswept residue (bounded by RS-6), and `G` = evicted-but-unreclaimed bytes (bounded by
-LIV-4's convergence bound × W-CHURN-RATE). ⚠ The bound's slack terms need ratified
+`store bytes ≤ live bytes + P-DL-CONC × W-CHUNK-BYTES-MAX + R + G + H`, where live =
+bytes of desired∪pinned committed chunks, the second term bounds in-flight fetch space,
+`R` = unswept residue (bounded by RS-6), `G` = evicted-but-unreclaimed bytes (bounded by
+LIV-4's convergence bound × W-CHURN-RATE), and `H` = bytes an undesired chunk holds
+while REQ-25's deletion floor withholds its batch (bounded by P-DEL-HOLD-MAX × the
+eviction rate the hold defers — unbounded if the hold never lapses, which is why it
+does). ⚠ The bound's slack terms need ratified
 values (ADR-19). The log store is additionally bounded by
 W-LOG-RATE × P-LOGS-RETENTION + the reclamation lag of RS-7.
 

--- a/spec/13-conformance-tdd.md
+++ b/spec/13-conformance-tdd.md
@@ -1,7 +1,7 @@
 # 13 — Conformance & TDD program
 
-Home doc for `CT`, `MG`, `HC`, `GAP`. **Mutable doc #1.** As of: **2026-07-25**
-(baseline commit `42d9aa1`). Statuses: **C** covered · **P** partial · **U** unchecked;
+Home doc for `CT`, `MG`, `HC`, `GAP`. **Mutable doc #1.** As of: **2026-07-26**
+(baseline commit `5c98f0d`). Statuses: **C** covered · **P** partial · **U** unchecked;
 `⊘` marks known-violated, `?` known-suspect.
 
 ## Harness architecture
@@ -62,7 +62,7 @@ abort(c):                                     # WP-13
 
 evict(c):                                     # WP-14
     require c in S.A and c not in S.N and S.L[c] == 0    # INV-12
-    require deletion_floor_ok(S)                         # REQ-25 ⚠
+    require deletion_floor_ok(S)                         # REQ-25
     S.A -= c
 
 recover():                                    # WP-15  (crash may precede)
@@ -121,13 +121,14 @@ prior page, within retention (INV-5) · heartbeat: map length = assignment slice
 ones-count consistent (INV-30) · gauges nonnegative and consistent with set algebra
 (INV-1).
 
-## Traceability matrix (as of 2026-07-25)
+## Traceability matrix (as of 2026-07-26)
 
-Statuses reflect the actual test inventory: 39 inline unit tests (4 `mvcc-chunks`-gated)
+Statuses reflect the actual test inventory: 46 inline unit tests (4 `mvcc-chunks`-gated)
 plus the conformance tier over the harness in `tests/harness/`: one binary per subject —
-`e2e` (the smoke path), `query_surface` (admission outcomes and the RP-20 taxonomy) and
-`query_concurrency` (separate by necessity, not topic: the OB signals are process-global,
-so a gauge assertion cannot share a process with other query-running tests).
+`e2e` (the smoke path), `query_surface` (admission outcomes and the RP-20 taxonomy),
+`assignment_faults` (the CT-4 document corpus) and `query_concurrency` (separate by
+necessity, not topic: the OB signals are process-global, so a gauge assertion cannot
+share a process with other query-running tests).
 WP/RP/CN/RS rows are enforced through the INV/LIV rows that encode them
 (see 07 §reading the catalog).
 
@@ -151,8 +152,8 @@ and `declared_gaps_cite_the_spec` keeps those lists pointing at identifiers here
 | REQ-21 | CT-1/5 | P | charge/refund/overload-keep unit-tested via mock seams |
 | REQ-22 | CT-6 | P | cap enforcement and its overload rejection covered by `query_concurrency`; queue-depth and reject-fan-out shedding still untested (needs the transport) |
 | REQ-23 | CT-2 | U | no crash-recovery test exists |
-| REQ-24 | CT-4/9 | U⊘ | known-violated (GAP-2, GAP-4) |
-| REQ-25 | CT-4 | U⊘ | no floor exists (GAP-3) |
+| REQ-24 | CT-4/9 | P⊘ | the documented termination paths are closed and covered by `assignment_faults`; unvalidated parsing and unbounded decompression remain (GAP-4) |
+| REQ-25 | CT-4 | C | floor unit-tested over the state machine and driven end-to-end: an empty slice is held with the data still readable, a restoring assignment releases it, the hold lapses on its own timer, the override wipes |
 
 ### Properties
 
@@ -189,7 +190,7 @@ and `declared_gaps_cite_the_spec` keeps those lists pointing at identifiers here
 | LIV-1 | CT-1/6 | U | |
 | LIV-2 | CT-1 | U | downloader has zero tests |
 | LIV-3 | CT-1/4 | U⊘ | unbounded today (GAP-8) |
-| LIV-4 | CT-1/3 | U⊘ | wake-up gap (GAP-6) |
+| LIV-4 | CT-1/3 | P⊘ | the deletion floor's hold lapses on its own timer, asserted with no further input event; the pin-release path keeps the wake-up gap (GAP-6) |
 | LIV-5 | CT-2/6 | U | |
 | LIV-6 | CT-3/6 | U? | at risk from store walks (GAP-15) |
 | LIV-7 | CT-5/7 | P | pagination/resumption unit-tested in memory; smoke adds one file-backed page read |
@@ -200,12 +201,12 @@ and `declared_gaps_cite_the_spec` keeps those lists pointing at identifiers here
 | LIV-12 | CT-5 | U | cold-start window known (GAP-25). The harness waits the window out before serving, so no test measures it yet |
 | LIV-13 | CT-4/7 | U | |
 | LIV-14 | CT-7 | U⊘ | log-store reclamation broken (GAP-10) |
-| FM-1 | CT-4/9 | U⊘ | known-violated (GAP-2) |
+| FM-1 | CT-4/9 | P⊘ | a bad address, an unreadable roster entry and a dead registry each leave the process serving; the unvalidated parse (GAP-4) is unprobed |
 | FM-2..3 | CT-4 | U | |
 | FM-10 | CT-4 | U | |
-| FM-11 | CT-4 | U⊘ | panic path (GAP-2) |
-| FM-12 | CT-4 | U⊘ | unbounded intake (GAP-4) |
-| FM-13 | CT-4 | U⊘ | no floor (GAP-3) |
+| FM-11 | CT-4 | C | HC-1's per-chunk bad address: that chunk alone is lost, the document applies, the alarm raises and clears |
+| FM-12 | CT-4 | P⊘ | an unreadable roster rejects the document whole and leaves the prior one in force; oversize and undecodable documents remain unbounded (GAP-4) |
+| FM-13 | CT-4 | P | the wipe case is covered by REQ-25's floor test; flip-flop churn (NG2 ordering) untested |
 | FM-14 | CT-7 | U⊘ | no age signal (GAP-23) |
 | FM-20..21 | CT-4 | U | |
 | FM-22 | CT-4 | U⊘ | no verification (GAP-5) |
@@ -222,21 +223,19 @@ and `declared_gaps_cite_the_spec` keeps those lists pointing at identifiers here
 | FM-44 | CT-4 | U⊘ | no cancellation (GAP-8) |
 | FM-50 | CT-2 | U | |
 | FM-51 | CT-2 | U⊘ | sweep-before-check (GAP-16) |
-| FM-52 | CT-4 | U⊘ | fatal at startup (GAP-2) |
+| FM-52 | CT-4 | P | HC-8 failing from before start: the worker serves, refuses queries with no allocation, and recovers when the registry answers. The P-STALL-MAX alarm bound is untested |
 | FM-53 | CT-4 | P | keep-previous-schemas unit-tested with a live stub server |
 | FM-54 | CT-2 | U | registration wait exists by design; externally invisible (GAP-28) |
 | FM-55 | CT-4 | U⊘ | misclassified and invisible (GAP-33) |
 | SLI-1..8 | CT-6 | U | no benchmark harness on the default branch |
 
-## Gap register (as of 2026-07-25)
+## Gap register (as of 2026-07-26)
 
 Priorities: **P0** active production risk · **P1** correctness hole with plausible
 trigger · **P2** bounded/rare · **P3** polish. "First test" = cheapest failing test.
 
 | GAP | Statement | Violates | Pri | First test |
 |---|---|---|---|---|
-| GAP-2 | Externally supplied content can terminate the process: a malformed file address in an assignment panics the reconciler; a registry error at startup is fatal; an unparseable roster peer id panics the assignment reader; a pathological per-chunk file count overflows the download-watchdog arithmetic | FM-1, FM-11, FM-52, REQ-24 | P0 | HC-1 assignment containing one bad URL: worker must survive, alarm, and keep serving |
-| GAP-3 | No reconciliation deletion floor: one empty/short assignment wipes the whole store next pass | REQ-25, FM-13, RS-2 | P0 | publish an assignment with zero chunks for the worker: store must survive with an alarm |
 | GAP-4 | Assignment intake is unverified and unbounded: unvalidated binary document parsed unsafely; decompression size uncapped | WP-2, FM-12, REQ-24, HZ-12 | P1 | HC-1 serves a decompression bomb and a truncated document: bounded memory, typed rejection, process alive |
 | GAP-5 | No payload/content verification anywhere: corrupt origin bytes commit (INV-13), power-loss-truncated chunks are adopted (CN-4), and local corruption surfaces as client-blamed `bad_request` (FM-32) | INV-13, CN-4, FM-22, FM-32 | P1 | HC-2 corrupts one file's bytes: commit must be refused (fails today) |
 | GAP-6 | Eviction is fragile: an I/O error panics the process (FM-31), and a chunk unpinned after the eviction pass is not retried until an unrelated event (LIV-4 unbounded) | LIV-4, FM-31, WP-14 | P1 | unassign a pinned chunk, release the pin, inject no further events: bytes must be reclaimed within P-EVICT-BOUND |
@@ -276,11 +275,15 @@ trigger · **P2** bounded/rare · **P3** polish. "First test" = cheapest failing
    library target so the tier can reach it. The SUT is assembled from the production subsystems
    and driven through the production functions, but the libp2p transport and the
    `P2PController` event loops are outside it — `harness::UNCOVERED` is the standing list.
-2. **Phase 1 — P0 gaps**: a failing test per gap, then the fix. MG-4 becomes meaningful
-   here. The query-concurrency gap is closed (test first, then a one-token fix; the
-   register row is gone and RP-4/REQ-22/INV-31/PF-1 no longer carry the exception).
-   GAP-2 and GAP-3 remain: their HC-1 fault knobs (`UnparseableFileUrl`,
-   `NoChunksForWorker`) exist, but no tests drive them yet.
+2. ~~**Phase 1 — P0 gaps**~~ **done**: a failing test per gap, then the fix, each
+   verified to fail without it. The query-concurrency gap went first (one-token fix).
+   The externally-triggered termination gap is closed across all four of its paths — a
+   bad address degrades per chunk (FM-11), reader panics are contained (ADR-21), the
+   download watchdog saturates, and a registry outage at startup degrades (FM-52). The
+   missing deletion floor is closed by ratifying and implementing ADR-17 (REQ-25). Both
+   register rows are gone, and REQ-24/25, FM-1/11/12/13/52 no longer carry the exception.
+   The alarms the closures needed are OB-12's first binding (`worker_alarms{reason}`,
+   IB-31). Lives in `tests/assignment_faults.rs`; MG-4 covers it.
 3. **Phase 2 — correctness core**: HC-4 reference model; CT-1 property runs; CT-2
    kill-point matrix (HC-7); CT-5 accounting reconciliation. Burn P1 gaps.
 4. **Phase 3 — robustness**: CT-3 swarms, CT-4 full corpus, CT-9 fuzz; P2 gaps.
@@ -305,7 +308,7 @@ trigger · **P2** bounded/rare · **P3** polish. "First test" = cheapest failing
 
 | HC | Capability | Needed by | Status | Note |
 |---|---|---|---|---|
-| HC-1 | scheduler simulator: network-state + assignment documents, fault corpus (IB-40/41) | CT-1..4, CT-8/9, MG-4/5 | **P** | `tests/harness/scheduler.rs`; real `sqd-assignments` builder over HTTP. Fault corpus holds 3 of the CT-4 cases (bad file URL, empty slice, truncated document) — the rest are unwritten |
+| HC-1 | scheduler simulator: network-state + assignment documents, fault corpus (IB-40/41) | CT-1..4, CT-8/9, MG-4/5 | **P** | `tests/harness/scheduler.rs`; real `sqd-assignments` builder over HTTP. Fault corpus holds 4 of the CT-4 cases (per-chunk bad address, empty slice, corrupt roster peer id, truncated document) — the rest are unwritten |
 | HC-2 | data-origin stub with byte ledger + injectors: delay, stall, error, corrupt, oversize (IB-42) | CT-1..4, CT-8, MG-4/5 | **P** | `tests/harness/origin.rs`; ledger = provenance oracle, wired into the smoke test's INV-13 check. Injectors: delay, stall, status, corrupt, truncate — oversize absent |
 | HC-3 | portal driver: keys, signed queries, disconnector, fuzzer (IB-10) | CT-1, CT-3..5, CT-9, MG-4 | **P** | `tests/harness/portal.rs`; seeded keys, genuinely signed queries, per-field deviation knobs. No disconnector (needs the transport) and no fuzzer |
 | HC-4 | reference model as executable oracle (§model) | CT-1..3 | U | |

--- a/spec/14-interface-binding.md
+++ b/spec/14-interface-binding.md
@@ -131,8 +131,10 @@ GET only: `/worker/status` → JSON `{"state":{"available":n,"downloading":n}}` 
 `chunks_downloaded/failed_download/removed` counters (OB-4), `used_storage_bytes`
 (OB-5), `running_queries` (OB-6), `num_queries_executed{status}` (OB-7),
 `query_result_size_bytes` (OB-8), `worker_status{worker_status}` (OB-12 assessed-state
-component), `worker_info_info{version}`. Signals OB-9/10/11/13 and the missing OB-4/7
-breakdowns have no binding yet — GAP-17/GAP-23 track the additions.
+component), `worker_alarms{reason}` (OB-12 alarm levels: `assignment_rejected`,
+`unresolvable_chunk_address`, `registry_unavailable`, `deletion_floor_hold`),
+`worker_info_info{version}`. Signals OB-9/10/11/13 and the missing OB-4/7 breakdowns
+have no binding yet — GAP-17/GAP-23 track the additions.
 
 **IB-32 — Configuration surface.** Flags/env (defaults live in the registry):
 
@@ -144,6 +146,8 @@ breakdowns have no binding yet — GAP-17/GAP-23 track the additions.
 | `--key` | `KEY_PATH` | identity key file (required) |
 | `--parallel-queries` | `PARALLEL_QUERIES` | P-Q-PAR |
 | `--concurrent-downloads` | `CONCURRENT_DOWNLOADS` | P-DL-CONC |
+| `--deletion-floor` | `DELETION_FLOOR` | P-DEL-FLOOR |
+| (positional) | `DELETION_HOLD_MAX_SEC` | P-DEL-HOLD-MAX |
 | `--query-threads` | `QUERY_THREADS` | engine pool width |
 | `--assignment-url` | `ASSIGNMENT_URL` | network-state document address |
 | (positional) | `S3_TIMEOUT` / `S3_READ_TIMEOUT` | P-DL-FILE-TIMEOUT / P-DL-STALL-TIMEOUT |

--- a/spec/15-parameters.md
+++ b/spec/15-parameters.md
@@ -1,6 +1,6 @@
 # 15 — Parameter registry
 
-**Mutable doc #2.** As of: 2026-07-25, baseline `42d9aa1`. Every `P-*` symbol used
+**Mutable doc #2.** As of: 2026-07-26, baseline `5c98f0d`. Every `P-*` symbol used
 anywhere in the suite has a row. **Observed** = what the implementation does today
 (configuration default where operator-settable). **Target** = the intended bound; ⚠ =
 proposed, unratified — ratification lands via the ADR named in the row (ADR-19 for the
@@ -76,7 +76,8 @@ batch unless stated).
 | P-START-ACCEPT | start → accepting queries (LIV-5) | unmeasured; recovery scan + residue sweep dominate | 120 s at W-CHUNKS ⚠ |
 | P-EVICT-BOUND | pin-release → reclamation (LIV-4) | **unbounded** — GAP-6 | 60 s ⚠ |
 | P-STALL-MAX | zero-progress-with-work alarm bound (LIV-9/13) | no alarm exists — GAP-17 | 600 s ⚠ |
-| P-DEL-FLOOR | max store fraction deletable per application without override (REQ-25) | no floor — GAP-3 | 50 % ⚠ (ADR-17) |
+| P-DEL-FLOOR | max store fraction deletable per application without override (REQ-25) | 50 % (`--deletion-floor`) | same (ADR-17) |
+| P-DEL-HOLD-MAX | how long the deletion floor withholds a batch before obeying it (REQ-25) | 3 600 s (`DELETION_HOLD_MAX_SEC`) | same (ADR-17) |
 | P-CONVERGE-SLACK | scheduling slack in convergence bounds (LIV-1/12) | — | 60 s ⚠ |
 | P-RECOVER-BOUND | overload-end → SLOs restored (LIV-8) | unmeasured | 60 s ⚠ |
 | P-REJECT-LATENCY | rejection response latency under storm (LIV-8) | unmeasured | 1 s ⚠ |

--- a/spec/README.md
+++ b/spec/README.md
@@ -84,14 +84,15 @@ retention/space lifecycle (10).
 | [ADR-14](decisions/ADR-14-fail-fast-subsystem-tree.md) | Fail-fast subsystem tree | Accepted (historical) |
 | [ADR-15](decisions/ADR-15-identity-stamp-not-instance-lock.md) | Identity stamp, not an instance lock | Accepted (historical) |
 | [ADR-16](decisions/ADR-16-opaque-assignment-ids-pull-only-status.md) | Opaque assignment ids; pull-only status | Accepted (historical) |
-| [ADR-17](decisions/ADR-17-reconciliation-deletion-floor.md) | Reconciliation deletion floor | Proposed |
+| [ADR-17](decisions/ADR-17-reconciliation-deletion-floor.md) | Reconciliation deletion floor | Accepted (2026-07-26) |
 | [ADR-18](decisions/ADR-18-bounded-validated-assignment-intake.md) | Bounded, validated assignment intake | Proposed |
 | [ADR-19](decisions/ADR-19-ratify-provisional-targets.md) | Ratify provisional SLO targets and gate thresholds | Proposed |
 | [ADR-20](decisions/ADR-20-freshness-rejection-attribution.md) | Freshness rejections are worker-fault outcomes | Proposed |
+| [ADR-21](decisions/ADR-21-contain-assignment-reader-panics.md) | Contain assignment-reader panics | Accepted (2026-07-26) |
 
 ## How to use this suite
 
-1. **Ratify**: review the four `Proposed` ADRs and every ⚠ target in
+1. **Ratify**: review the three `Proposed` ADRs and every ⚠ target in
    [15-parameters.md](15-parameters.md); acceptance turns ⚠ into committed bounds.
 2. **Build the harness** in the order given in
    [13-conformance-tdd.md](13-conformance-tdd.md) §build order: input simulators and

--- a/spec/decisions/ADR-17-reconciliation-deletion-floor.md
+++ b/spec/decisions/ADR-17-reconciliation-deletion-floor.md
@@ -1,25 +1,49 @@
 # ADR-17 — Reconciliation deletion floor
 
-Status: Proposed
+Status: Accepted (2026-07-26)
 
 ## Context
 
 Reconciliation deletes whatever the assignment stops naming. A scheduler bug, a
 truncated document, or a worker briefly missing from the roster therefore wipes a
-multi-terabyte store in one pass — a fleet-wide amplifier with hours-to-days of
-re-download cost. An earlier code comment ("prevent accidental massive removals")
-acknowledged the risk; the guard was never built and the comment was lost in a
-refactor. Trade-off: any floor delays legitimate large rebalances.
+multi-terabyte store in one pass — a fleet-wide amplifier, hitting every worker at once,
+with hours-to-days of re-download cost. An earlier code comment ("prevent accidental
+massive removals") acknowledged the risk; the guard was never built and the comment was
+lost in a refactor.
+
+The costs run the other way too. A guard that refuses outright strands disk on a worker
+the network has legitimately shrunk, and because eviction precedes fetching in the
+reconciliation loop, a worker that cannot free space cannot converge on a large
+rebalance without twice the headroom.
 
 ## Decision
 
-Proposed: a single assignment application may evict at most the P-DEL-FLOOR fraction
-of the store's chunks. Beyond it, eviction pauses, an alarm level raises (OB-12), and
-the excess is re-evaluated on the next intake cycle; an explicit operator override
-releases the hold for sanctioned rebalances.
+An assignment application that would evict more than the P-DEL-FLOOR fraction of the
+stored chunks evicts none of them: the batch is held whole, an alarm level is raised
+(OB-12), and the same test runs again on every reconciliation pass, so a restoring
+assignment releases the hold by itself. Held-but-undesired chunks stay readable —
+eviction, not the assignment, is what ends availability.
+
+The hold is a **delay, not a veto**. After P-DEL-HOLD-MAX the batch goes through, and
+the reconciliation loop wakes on its own timer to apply it, so LIV-4 needs no further
+input event. The window is evidence about one batch and belongs to it: a different
+wipe-inducing assignment earns its own, and a member left behind by a pin keeps the
+authorization the batch already earned rather than facing a second window. The bound separates the two cases by their own nature rather than by asking
+an operator to tell them apart: a scheduler glitch is corrected by the next publication,
+a real shrink keeps being republished for the whole window. What the wait buys is
+machine self-correction; a human noticing the alarm in time is a bonus, not the premise.
+
+The batch is held rather than trimmed to the floor, because trimming still wipes the
+store, just over several passes. The operator override is the floor itself: raising it
+to 1 restores unguarded reconciliation.
 
 ## Consequences
 
-A wipe becomes a held, alarmed, recoverable state instead of an accident. Legitimate
-mass rebalances need an override or several cycles. Encodes REQ-25, RS-2; closes
-GAP-3 when accepted and implemented.
+An accidental wipe becomes a held, alarmed, self-resolving state. A deliberate one costs
+P-DEL-HOLD-MAX. Held bytes are a bounded excess term in RS-3 and a bounded delay in
+LIV-4 — an unbounded hold would violate both outright. A scheduler bug that outlives the
+window still wipes: this guards against a glitch, not a sustained fault.
+
+Not in conflict with RS-1's ban on age-based eviction: a held chunk still leaves because
+the assignment stopped naming it, only later. Encodes REQ-25, RS-2, and closes the
+missing-floor gap.

--- a/spec/decisions/ADR-18-bounded-validated-assignment-intake.md
+++ b/spec/decisions/ADR-18-bounded-validated-assignment-intake.md
@@ -5,11 +5,11 @@ Status: Proposed
 ## Context
 
 ADR-3 accepted skipping document verification when the verifier cost over a minute.
-Since then: the panic on a malformed per-chunk address is proven remote-triggerable
-(GAP-2), decompression is unbounded (GAP-4/HZ-12), file names from the document reach
-filesystem paths without traversal checks, and origin payloads commit unverified
-(GAP-5). The one-minute measurement predates the binary-format rework and has not
-been re-taken.
+Since then: the reader's panic paths proved remote-triggerable and are now merely
+contained, not removed (ADR-21); decompression is unbounded (GAP-4/HZ-12); file names
+from the document reach filesystem paths without traversal checks; and origin payloads
+commit unverified (GAP-5). The one-minute measurement predates the binary-format rework
+and has not been re-taken.
 
 ## Decision
 

--- a/spec/decisions/ADR-21-contain-assignment-reader-panics.md
+++ b/spec/decisions/ADR-21-contain-assignment-reader-panics.md
@@ -1,0 +1,31 @@
+# ADR-21 — Contain assignment-reader panics
+
+Status: Accepted (2026-07-26)
+
+## Context
+
+ADR-3 accepted parsing assignment documents unverified, so the reader works on bytes
+nothing has checked. It panics on input it cannot make sense of — an unparseable roster
+peer id is the proven case — and ADR-14's supervision tree turns any panic in the
+intake loop into a process exit. That is FM-1 violated by a document anyone upstream of
+the worker can publish. Fixing it properly means ADR-18's structural validation, which
+is a larger change and is not ratified.
+
+## Decision
+
+Reading a document is a panic-catching boundary, the same shape ADR-5 gave the query
+engine: a panic below it becomes a rejected document (FM-12), the last good assignment
+stays in force, and an alarm is raised. The task boundary above it repeats the catch, so
+a panic on a path the reader does not own still costs one document.
+
+Containment is not validation. Per-item degradation (FM-11's "this chunk's address is
+unusable") stays a typed `None` on the address path, not a caught panic, and the
+unvalidated-parse hazard (GAP-4) is unchanged: a document crafted to corrupt memory
+rather than to panic is still out of scope until ADR-18.
+
+## Consequences
+
+FM-1 holds against the documented panic paths without waiting on ADR-18, at the cost of
+a coarse failure mode — a panic loses the whole document, including the chunks that
+were readable. Sentry still sees the panic, so containment does not hide the bug.
+Shapes FM-1, FM-12, REQ-24.

--- a/spec/tools/check_spec.py
+++ b/spec/tools/check_spec.py
@@ -297,11 +297,18 @@ class Suite:
     # -- checks --------------------------------------------------------------
 
     def check_reference_integrity(self):
+        # Closing a gap deletes its row, but an accepted ADR is append-only: its context
+        # keeps citing ids the register has since dropped. A proposed one is still editable,
+        # so it stays checked.
+        frozen = {info[0] for info in self.adr_files.values()
+                  if (info[2] or "").startswith("Accepted")}
         for (prefix, num), sites in sorted(self.refs.items()):
             if prefix == "ADR":
                 continue
             if (prefix, num) not in self.defs:
                 hard_sites = [s for s in sites if s[2]]
+                if prefix == "GAP":
+                    hard_sites = [s for s in hard_sites if s[0] not in frozen]
                 if hard_sites:
                     p, l, _ = hard_sites[0]
                     self.add("id-undefined", p, l,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,6 +30,14 @@ pub struct Args {
     #[clap(long, env, default_value_t = 3)]
     pub concurrent_downloads: usize,
 
+    /// Largest share of the stored chunks one assignment may delete (P-DEL-FLOOR). A larger
+    /// batch is held with an alarm; set to 1 to release it for a sanctioned rebalance.
+    #[clap(long, env, default_value_t = 0.5)]
+    pub deletion_floor: f64,
+
+    #[clap(env = "DELETION_HOLD_MAX_SEC", hide(true), value_parser=parse_seconds, default_value = "3600")]
+    pub deletion_hold_max: Duration,
+
     #[clap(env, hide(true), value_parser=parse_seconds, default_value = "60")]
     pub s3_timeout: Duration,
 

--- a/src/compute_units/allocations_checker.rs
+++ b/src/compute_units/allocations_checker.rs
@@ -1,36 +1,40 @@
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
-use anyhow::Result;
 use parking_lot::Mutex;
 use sqd_network_transport::PeerId;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
+use crate::metrics::{self, AlarmReason};
+
 use super::{rate_limiter::RateLimiter, RateLimitStatus};
 
 pub struct AllocationsChecker {
     client: Box<dyn sqd_contract_client::Client>,
-    own_id: sqd_contract_client::U256,
+    peer_id: PeerId,
+    /// Resolved by the polling loop, not at construction: FM-52 wants a registry outage to
+    /// degrade service, not to refuse the start.
+    own_id: Mutex<Option<sqd_contract_client::U256>>,
     rate_limiter: Mutex<RateLimiter>,
     polling_interval: Duration,
     current_epoch: AtomicU32,
 }
 
 impl AllocationsChecker {
-    pub async fn new(
+    pub fn new(
         client: Box<dyn sqd_contract_client::Client>,
         peer_id: PeerId,
         polling_interval: Duration,
-    ) -> Result<Self> {
-        let own_id = client.worker_id(peer_id).await?;
-        Ok(Self {
+    ) -> Self {
+        Self {
             client,
-            own_id,
+            peer_id,
+            own_id: Mutex::new(None),
             rate_limiter: Default::default(),
             polling_interval,
             current_epoch: AtomicU32::new(0),
-        })
+        }
     }
 
     /// The latest on-chain epoch observed by the polling loop, or `None` if not yet fetched.
@@ -62,20 +66,26 @@ impl AllocationsChecker {
                 _ = cancellation_token.cancelled() => { break; },
             );
 
+            let Some(own_id) = self.own_id().await else {
+                continue;
+            };
+
             debug!("Getting current epoch");
             let epoch = match self.client.current_epoch().await {
                 Ok(epoch) => epoch,
                 Err(e) => {
                     warn!("Couldn't get current epoch: {e:?}");
+                    metrics::set_alarm(AlarmReason::RegistryUnavailable, true);
                     continue;
                 }
             };
             self.current_epoch.store(epoch, Ordering::Relaxed);
+            metrics::set_alarm(AlarmReason::RegistryUnavailable, false);
             if epoch > current_epoch {
                 info!("New epoch started. Updating allocations");
                 match tokio::try_join!(
                     self.client.epoch_length(),
-                    self.client.portal_clusters(self.own_id)
+                    self.client.portal_clusters(own_id)
                 ) {
                     Ok((epoch_length, clusters)) => {
                         self.rate_limiter
@@ -85,10 +95,31 @@ impl AllocationsChecker {
                     }
                     Err(e) => {
                         warn!("Couldn't fetch CU allocations: {e:?}");
+                        metrics::set_alarm(AlarmReason::RegistryUnavailable, true);
                     }
                 }
             }
         }
         info!("Allocations update task finished");
+    }
+
+    /// Looked up once and cached. Until it answers, the worker runs without allocations.
+    async fn own_id(&self) -> Option<sqd_contract_client::U256> {
+        let cached = *self.own_id.lock();
+        if cached.is_some() {
+            return cached;
+        }
+        match self.client.worker_id(self.peer_id).await {
+            Ok(own_id) => {
+                info!("Worker is registered on chain as {own_id}");
+                *self.own_id.lock() = Some(own_id);
+                Some(own_id)
+            }
+            Err(e) => {
+                warn!("Couldn't look up the worker's on-chain id: {e:?}");
+                metrics::set_alarm(AlarmReason::RegistryUnavailable, true);
+                None
+            }
+        }
     }
 }

--- a/src/controller/p2p.rs
+++ b/src/controller/p2p.rs
@@ -117,8 +117,7 @@ pub async fn create_p2p_controller(
         transport_builder.contract_client(),
         worker_id,
         args.network_polling_interval,
-    )
-    .await?;
+    );
 
     let worker_status = get_worker_status(&worker, allocations_checker.current_epoch()).await;
 
@@ -335,7 +334,13 @@ impl<EventStream: Stream<Item = WorkerEvent> + Send + 'static> P2PController<Eve
                     })
                     .instrument(tracing::info_span!("set_assignment", id))
                     .await
-                    .expect("register_assignment shouldn't panic");
+                    .unwrap_or_else(|e| {
+                        // ADR-21's backstop: a panic the reader missed still costs one
+                        // document, not the process (FM-1).
+                        warn!("Applying assignment {id} panicked: {e}");
+                        metrics::set_alarm(metrics::AlarmReason::AssignmentRejected, true);
+                        false
+                    });
 
                     #[cfg(feature = "mvcc-chunks")]
                     if registered {

--- a/src/controller/worker.rs
+++ b/src/controller/worker.rs
@@ -28,6 +28,7 @@ use crate::{
     query::result::{QueryError, QueryOk, QueryResult},
     storage::manager::{self, StateManager},
     types::dataset::Dataset,
+    util::panic_message,
 };
 
 // Use the maximum value for the uncompressed result. After compression, the result will be smaller.
@@ -97,6 +98,10 @@ impl Worker {
 
     pub async fn status(&self) -> manager::Status {
         self.state_manager.current_status().await
+    }
+
+    pub fn alarms(&self) -> manager::Alarms {
+        self.state_manager.alarms()
     }
 
     /// Subscribe to the "assignment fully applied" signal, so callers can refresh
@@ -224,12 +229,10 @@ impl Worker {
                 ))
             }))
             .unwrap_or_else(|panic| {
-                let msg = panic
-                    .downcast_ref::<&str>()
-                    .map(|s| s.to_string())
-                    .or_else(|| panic.downcast_ref::<String>().cloned())
-                    .unwrap_or_else(|| "unknown panic".to_string());
-                Err(QueryError::from(anyhow::anyhow!("Query panicked: {msg}")))
+                Err(QueryError::from(anyhow::anyhow!(
+                    "Query panicked: {}",
+                    panic_message(panic)
+                )))
             });
             tx.send(result).unwrap_or_else(|_| {
                 tracing::warn!("Query runner didn't wait for the result");
@@ -348,12 +351,10 @@ impl Worker {
                 ))
             }))
             .unwrap_or_else(|panic| {
-                let msg = panic
-                    .downcast_ref::<&str>()
-                    .map(|s| s.to_string())
-                    .or_else(|| panic.downcast_ref::<String>().cloned())
-                    .unwrap_or_else(|| "unknown panic".to_string());
-                Err(QueryError::from(anyhow::anyhow!("Query panicked: {msg}")))
+                Err(QueryError::from(anyhow::anyhow!(
+                    "Query panicked: {}",
+                    panic_message(panic)
+                )))
             });
             tx.send(result).unwrap_or_else(|_| {
                 tracing::warn!("Query runner didn't wait for the result");
@@ -375,12 +376,10 @@ where
     sqd_polars::POOL.spawn(move || {
         let result =
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).unwrap_or_else(|panic| {
-                let msg = panic
-                    .downcast_ref::<&str>()
-                    .map(|s| s.to_string())
-                    .or_else(|| panic.downcast_ref::<String>().cloned())
-                    .unwrap_or_else(|| "unknown panic".to_string());
-                Err(QueryError::from(anyhow::anyhow!("Query panicked: {msg}")))
+                Err(QueryError::from(anyhow::anyhow!(
+                    "Query panicked: {}",
+                    panic_message(panic)
+                )))
             });
         tx.send(result).unwrap_or_else(|_| {
             tracing::warn!("Query runner didn't wait for the result");

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -25,6 +25,26 @@ pub enum QueryStatus {
     ServerError,
 }
 
+/// OB-12 alarm reasons. A level, not an event: raised while the condition holds.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum AlarmReason {
+    /// An assignment document was rejected whole (FM-12).
+    AssignmentRejected,
+    /// Some assigned chunk's download address doesn't resolve (FM-11).
+    UnresolvableChunkAddress,
+    /// The chain registry is unreachable or erroring (FM-52).
+    RegistryUnavailable,
+    /// Eviction is withheld by the P-DEL-FLOOR gate (REQ-25).
+    DeletionFloorHold,
+}
+
+const ALARM_REASONS: [AlarmReason; 4] = [
+    AlarmReason::AssignmentRejected,
+    AlarmReason::UnresolvableChunkAddress,
+    AlarmReason::RegistryUnavailable,
+    AlarmReason::DeletionFloorHold,
+];
+
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 pub struct WorkerInfoLabels {
     pub version: String,
@@ -40,11 +60,17 @@ struct QueryExecutedLabels {
     status: QueryStatus,
 }
 
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct AlarmLabels {
+    reason: AlarmReason,
+}
+
 lazy_static::lazy_static! {
     // Worker info metric (kept as worker_info_info for backward compatibility)
     pub static ref WORKER_INFO: Family<WorkerInfoLabels, Gauge> = Default::default();
 
     static ref STATUS: Family<StatusLabels, Gauge> = Default::default();
+    static ref ALARMS: Family<AlarmLabels, Gauge> = Default::default();
     pub static ref CHUNKS_AVAILABLE: Gauge = Default::default();
     pub static ref CHUNKS_DOWNLOADING: Gauge = Default::default();
     pub static ref CHUNKS_PENDING: Gauge = Default::default();
@@ -66,6 +92,17 @@ pub fn set_status(status: WorkerStatus) {
             worker_status: status,
         })
         .set(1);
+}
+
+/// OB-12: raise or clear `reason`'s alarm level.
+pub fn set_alarm(reason: AlarmReason, raised: bool) {
+    ALARMS
+        .get_or_create(&AlarmLabels { reason })
+        .set(raised as i64);
+}
+
+pub fn alarm_raised(reason: AlarmReason) -> bool {
+    ALARMS.get_or_create(&AlarmLabels { reason }).get() != 0
 }
 
 pub fn query_executed(result: &QueryResult) {
@@ -154,7 +191,16 @@ pub fn register_metrics(registry: &mut Registry, version: String) {
         RUNNING_QUERIES.clone(),
     );
     registry.register("worker_status", "Status of the worker", STATUS.clone());
+    registry.register(
+        "worker_alarms",
+        "Reason-coded alarm levels: 1 while the condition holds",
+        ALARMS.clone(),
+    );
     set_status(WorkerStatus::Starting);
+    // Exported from the start, so one read answers "is anything wrong".
+    for reason in ALARM_REASONS {
+        set_alarm(reason, false);
+    }
 }
 
 impl prometheus_client::encoding::EncodeLabelValue for WorkerStatus {
@@ -168,6 +214,36 @@ impl prometheus_client::encoding::EncodeLabelValue for WorkerStatus {
             WorkerStatus::Active => "active",
         };
         encoder.write_str(status)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// OB-12 wants a level, not an event: the same read must report raised and cleared.
+    #[test]
+    fn alarm_levels_are_readable_and_clearable() {
+        // A reason no other unit test touches, so this holds whatever else runs.
+        let reason = AlarmReason::DeletionFloorHold;
+        assert!(!alarm_raised(reason));
+        set_alarm(reason, true);
+        assert!(alarm_raised(reason));
+        set_alarm(reason, false);
+        assert!(!alarm_raised(reason));
+    }
+}
+
+impl prometheus_client::encoding::EncodeLabelValue for AlarmReason {
+    fn encode(&self, encoder: &mut LabelValueEncoder) -> Result<(), std::fmt::Error> {
+        let reason = match self {
+            AlarmReason::AssignmentRejected => "assignment_rejected",
+            AlarmReason::UnresolvableChunkAddress => "unresolvable_chunk_address",
+            AlarmReason::RegistryUnavailable => "registry_unavailable",
+            AlarmReason::DeletionFloorHold => "deletion_floor_hold",
+        };
+        encoder.write_str(reason)?;
         Ok(())
     }
 }

--- a/src/storage/datasets_index.rs
+++ b/src/storage/datasets_index.rs
@@ -4,7 +4,7 @@ use reqwest::Url;
 use sqd_network_transport::Keypair;
 use tracing::error;
 
-use crate::types::state::ChunkRef;
+use crate::{types::state::ChunkRef, util::panic_message};
 use sqd_assignments::ChunkRef as ChunkAssignmentRef;
 
 pub struct DatasetsIndex {
@@ -56,7 +56,25 @@ impl DatasetsIndex {
 
         Some(result)
     }
+    /// Reads this worker's slice out of `assignment`.
+    ///
+    /// The reader parses an unvalidated document (ADR-3, GAP-4) and panics on input it can't
+    /// read — a roster peer id, among others. ADR-21 contains that: a document nobody can
+    /// read costs one document (FM-12), not the process (FM-1).
     pub fn new(
+        assignment: sqd_assignments::Assignment,
+        id: impl Into<String>,
+        key: &Keypair,
+    ) -> anyhow::Result<Self> {
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            Self::read(assignment, id, key)
+        }))
+        .unwrap_or_else(|payload| {
+            anyhow::bail!("assignment reader panicked: {}", panic_message(payload))
+        })
+    }
+
+    fn read(
         assignment: sqd_assignments::Assignment,
         id: impl Into<String>,
         key: &Keypair,

--- a/src/storage/downloader.rs
+++ b/src/storage/downloader.rs
@@ -59,10 +59,9 @@ impl ChunkDownloader {
             panic!("Chunk {chunk} is already being downloaded");
         }
 
-        let num_files = files.len();
+        let watchdog = watchdog_timeout(self.args.s3_timeout, files.len());
         let client = self.reqwest_client.clone();
         let current_delay = self.current_delay;
-        let s3_timeout = self.args.s3_timeout;
         self.futures.push(tokio::spawn(async move {
             if current_delay > Duration::ZERO {
                 let sleep = rand::rng().random_range((current_delay / 2)..current_delay);
@@ -76,7 +75,7 @@ impl ChunkDownloader {
                 result = download_dir(files, dst, &client, &headers) => {
                     (chunk, result)
                 }
-                _ = tokio::time::sleep(s3_timeout * num_files as u32) => {
+                _ = tokio::time::sleep(watchdog) => {
                     (chunk, Err(anyhow!("Download timed out")))
                 }
                 _ = cancel_token.cancelled_owned() => {
@@ -127,6 +126,12 @@ impl ChunkDownloader {
     }
 }
 
+/// Whole-chunk download bound: one per-file timeout per file. The file count comes from the
+/// document, so it saturates rather than overflowing, and zero files still get one timeout.
+fn watchdog_timeout(per_file: Duration, num_files: usize) -> Duration {
+    per_file.saturating_mul(u32::try_from(num_files.max(1)).unwrap_or(u32::MAX))
+}
+
 /// Either downloads the entire directory or nothing at all.
 /// This function is cancel-safe. If it is not awaited until the end,
 /// it will clean up temporary results.
@@ -149,6 +154,28 @@ async fn download_dir(
     .await?;
     guard.persist(dst_dir)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// FM-1: a document-chosen file count must not panic the task. `Duration * u32` does.
+    #[test]
+    fn watchdog_survives_any_file_count() {
+        let per_file = Duration::from_secs(60);
+        assert_eq!(watchdog_timeout(per_file, 3), Duration::from_secs(180));
+        assert_eq!(watchdog_timeout(per_file, 0), per_file);
+        assert_eq!(
+            watchdog_timeout(per_file, usize::MAX),
+            per_file.saturating_mul(u32::MAX)
+        );
+        assert_eq!(
+            watchdog_timeout(Duration::MAX, usize::MAX),
+            Duration::MAX,
+            "the bound saturates instead of overflowing"
+        );
+    }
 }
 
 #[instrument(skip_all)]

--- a/src/storage/manager.rs
+++ b/src/storage/manager.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use camino::Utf8PathBuf as PathBuf;
@@ -22,7 +23,7 @@ use super::{
     downloader::ChunkDownloader,
     layout::{self, DataChunk},
     local_fs::{add_temp_prefix, LocalFs},
-    state::{State, UpdateStatus},
+    state::{DeletionFloor, State, UpdateStatus},
     Filesystem,
 };
 
@@ -46,6 +47,15 @@ pub struct Status {
     pub assignment_id: Option<String>,
     #[cfg(feature = "mvcc-chunks")]
     pub last_applied_assignment_id: Option<String>,
+}
+
+/// Reconciliation health, per instance — the OB-12 gauges are process-global.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Alarms {
+    /// Assigned chunks that cannot be fetched because their addresses don't resolve (FM-11).
+    pub unresolvable_chunks: usize,
+    /// Evictions withheld by the P-DEL-FLOOR gate (REQ-25), if any.
+    pub deletion_hold: Option<usize>,
 }
 
 #[cfg(feature = "mvcc-chunks")]
@@ -74,7 +84,10 @@ impl StateManager {
 
         Ok(Self {
             fs,
-            state: Mutex::new(State::new(existing_chunks)),
+            state: Mutex::new(State::new(
+                existing_chunks,
+                DeletionFloor::new(args.deletion_floor, args.deletion_hold_max),
+            )),
             concurrent_downloads,
             worker_id,
             notify: tokio::sync::Notify::new(),
@@ -89,6 +102,9 @@ impl StateManager {
 
     pub async fn run(&self, cancellation_token: CancellationToken) {
         let mut downloader = ChunkDownloader::new(self.worker_id, self.args.clone());
+        // Set while the deletion floor withholds a batch: LIV-4 wants that eviction without a
+        // further input event, and nothing else here would wake for it.
+        let mut hold_wakeup: Option<Duration> = None;
         loop {
             self.state.lock().report_status();
             let stored_bytes = get_directory_size(self.fs.root.clone()).await;
@@ -96,6 +112,7 @@ impl StateManager {
 
             tokio::select! {
                 _ = self.notify.notified() => {}
+                _ = sleep_opt(hold_wakeup) => {}
                 (chunk, result) = downloader.downloaded() => {
                     match result {
                         Ok(()) => {
@@ -117,7 +134,17 @@ impl StateManager {
                 downloader.cancel(&chunk);
             }
 
-            let removals = self.state.lock().take_removals();
+            let removals = {
+                let now = Instant::now();
+                let mut state = self.state.lock();
+                let removals = state.take_removals(now);
+                hold_wakeup = state.deletion_hold_remaining(now);
+                removals
+            };
+            metrics::set_alarm(
+                metrics::AlarmReason::DeletionFloorHold,
+                hold_wakeup.is_some(),
+            );
             for chunk in removals {
                 info!("Removing chunk {chunk}");
                 self.drop_chunk(&chunk)
@@ -130,18 +157,29 @@ impl StateManager {
             let Some(dataset_index) = guard.as_ref() else {
                 continue;
             };
+            // Held out of the pending set for the rest of the pass, so the loop terminates.
+            let mut deferred = Vec::new();
             while downloader.download_count() < self.concurrent_downloads {
-                if let Some(chunk_ref) = self.state.lock().take_next_download() {
-                    info!("Downloading chunk {chunk_ref}");
-                    let dst = self.chunk_path(&chunk_ref);
-                    let files = dataset_index
-                        .list_files(&chunk_ref)
-                        .unwrap_or_else(|| panic!("Dataset {} not found", chunk_ref.dataset));
-                    let headers = dataset_index.get_headers().clone();
-                    downloader.start_download(chunk_ref, dst, files, headers);
-                } else {
+                let Some(chunk_ref) = self.state.lock().take_next_download() else {
                     break;
+                };
+                // FM-11: a bad address costs its own chunk, not the document or the process.
+                let Some(files) = dataset_index.list_files(&chunk_ref) else {
+                    warn!("No resolvable download address for chunk {chunk_ref}");
+                    deferred.push(chunk_ref);
+                    continue;
+                };
+                info!("Downloading chunk {chunk_ref}");
+                let dst = self.chunk_path(&chunk_ref);
+                let headers = dataset_index.get_headers().clone();
+                downloader.start_download(chunk_ref, dst, files, headers);
+            }
+            if !deferred.is_empty() {
+                let mut state = self.state.lock();
+                for chunk in deferred {
+                    state.defer_unresolvable(chunk);
                 }
+                metrics::set_alarm(metrics::AlarmReason::UnresolvableChunkAddress, true);
             }
             #[cfg(feature = "mvcc-chunks")]
             {
@@ -220,6 +258,8 @@ impl StateManager {
             Ok(result) => result,
             Err(e) => {
                 metrics::set_status(metrics::WorkerStatus::NotRegistered);
+                // WP-2/FM-12: rejected whole; the last good assignment stays in force.
+                metrics::set_alarm(metrics::AlarmReason::AssignmentRejected, true);
                 error!("Can not get assigned chunks: {e}");
                 return false;
             }
@@ -230,6 +270,9 @@ impl StateManager {
         let mut index = self.datasets_index.lock();
         let mut state = self.state.lock();
 
+        // A new index may resolve what the old one couldn't, even with the chunk set
+        // unchanged — and an unchanged set notifies nobody.
+        let had_unresolvable = state.clear_unresolvable();
         match state.set_desired_chunks(chunks) {
             UpdateStatus::Unchanged => {}
             UpdateStatus::Updated => {
@@ -240,6 +283,12 @@ impl StateManager {
         *index = Some(datasets_index);
         drop(state);
         drop(index);
+
+        if had_unresolvable {
+            self.notify.notify_one();
+        }
+        metrics::set_alarm(metrics::AlarmReason::UnresolvableChunkAddress, false);
+        metrics::set_alarm(metrics::AlarmReason::AssignmentRejected, false);
 
         #[cfg(feature = "mvcc-chunks")]
         {
@@ -289,6 +338,15 @@ impl StateManager {
                 }
                 _ = cancellation_token.cancelled() => return false,
             }
+        }
+    }
+
+    /// What this instance is alarming on (OB-12).
+    pub fn alarms(&self) -> Alarms {
+        let state = self.state.lock();
+        Alarms {
+            unresolvable_chunks: state.unresolvable_chunks(),
+            deletion_hold: state.deletion_hold(),
         }
     }
 
@@ -368,6 +426,14 @@ fn mark_assignment_applied_if_ready(
     }
     assignment_application.last_applied_assignment_id = Some(current_assignment_id.clone());
     let _ = assignment_applied_tx.send(Some(current_assignment_id));
+}
+
+/// A `sleep` that never fires when there is no deadline, for use as a `select!` arm.
+async fn sleep_opt(delay: Option<Duration>) {
+    match delay {
+        Some(delay) => tokio::time::sleep(delay).await,
+        None => std::future::pending().await,
+    }
 }
 
 #[instrument(skip_all)]
@@ -463,7 +529,9 @@ mod tests {
 
         use parking_lot::Mutex;
 
-        use super::{mark_assignment_applied_if_ready, AssignmentApplicationStatus, State};
+        use super::{
+            mark_assignment_applied_if_ready, AssignmentApplicationStatus, DeletionFloor, State,
+        };
         use crate::types::state::{ChunkRef, ChunkSet};
 
         let chunk = |id: &str| ChunkRef {
@@ -475,7 +543,10 @@ mod tests {
 
         // Assignment A only needs `chunk_a`, which is already available, and is
         // already marked as applied (steady state before the race begins).
-        let state = Mutex::new(State::new([chunk_a.clone()].into_iter().collect()));
+        let state = Mutex::new(State::new(
+            [chunk_a.clone()].into_iter().collect(),
+            DeletionFloor::default(),
+        ));
         let assignment_application = Mutex::new(AssignmentApplicationStatus {
             current_assignment_id: Some("A".to_owned()),
             last_applied_assignment_id: Some("A".to_owned()),

--- a/src/storage/state.rs
+++ b/src/storage/state.rs
@@ -1,6 +1,7 @@
 use itertools::Itertools;
 use std::collections::HashMap;
-use tracing::{info, instrument};
+use std::time::{Duration, Instant};
+use tracing::{info, instrument, warn};
 
 use crate::{
     metrics,
@@ -14,6 +15,57 @@ pub struct State {
     desired: ChunkSet,
     to_download: ChunkSet, // to_download is always equal to desired.diff(available).diff(downloading)
     locks: HashMap<ChunkRef, u8>, // stores ref count for each chunk
+    // assigned chunks whose download addresses don't resolve (FM-11)
+    unresolvable: ChunkSet,
+    deletion_floor: DeletionFloor,
+    deletion_hold: Option<DeletionHold>,
+}
+
+/// P-DEL-FLOOR / P-DEL-HOLD-MAX (REQ-25, ADR-17): the share of the stored chunks one
+/// assignment may evict, and how long a larger batch waits before it goes through anyway.
+///
+/// The batch is held whole rather than trimmed to fit — trimming still wipes the store, just
+/// over several passes. The wait separates the two cases by their own nature: a scheduler
+/// glitch is corrected by the next publication, a real shrink keeps being republished.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DeletionFloor {
+    fraction: f64,
+    hold_max: Duration,
+}
+
+/// What the floor is doing about one eviction batch. The window is evidence that the network
+/// means this batch, so it belongs to the batch: a different one earns its own.
+#[derive(Debug)]
+enum DeletionHold {
+    /// Withheld since `since`; the same batch has to stand for the whole window.
+    Holding { batch: ChunkSet, since: Instant },
+    /// The window lapsed. Members still pinned then evict as their pins release, rather than
+    /// facing a fresh window each time one does.
+    Authorized { batch: ChunkSet },
+}
+
+impl Default for DeletionFloor {
+    fn default() -> Self {
+        Self::new(0.5, Duration::from_secs(3600))
+    }
+}
+
+impl DeletionFloor {
+    /// `fraction >= 1` disables the gate: ADR-17's operator override. Clamped to `0..=1`.
+    pub fn new(fraction: f64, hold_max: Duration) -> Self {
+        Self {
+            fraction: if fraction.is_nan() {
+                0.0
+            } else {
+                fraction.clamp(0.0, 1.0)
+            },
+            hold_max,
+        }
+    }
+
+    fn permits(&self, evicting: usize, stored: usize) -> bool {
+        self.fraction >= 1.0 || evicting as f64 <= self.fraction * stored as f64
+    }
 }
 
 #[derive(Debug)]
@@ -28,10 +80,11 @@ pub struct Status {
 }
 
 impl State {
-    pub fn new(available: ChunkSet) -> Self {
+    pub fn new(available: ChunkSet, deletion_floor: DeletionFloor) -> Self {
         Self {
             available: available.clone(),
             desired: available,
+            deletion_floor,
             ..Default::default()
         }
     }
@@ -82,7 +135,28 @@ impl State {
         Some(chunk_ref)
     }
 
-    pub fn take_removals(&mut self) -> Vec<ChunkRef> {
+    pub fn take_removals(&mut self, now: Instant) -> Vec<ChunkRef> {
+        // Everything the assignment dropped, pinned or not. A pin lasts one query, so counting
+        // only what is evictable right now would let a wipe through in instalments as pins
+        // drain — the floor bounds the document's blast radius, not one pass's.
+        let batch: ChunkSet = self
+            .available
+            .iter()
+            .filter(|chunk| !self.desired.contains(*chunk))
+            .cloned()
+            .collect();
+
+        if self
+            .deletion_floor
+            .permits(batch.len(), self.available.len())
+        {
+            if self.deletion_hold.take().is_some() {
+                info!("Deletion hold released: the batch is back under the floor");
+            }
+        } else if !self.authorize(batch, now) {
+            return Vec::new();
+        }
+
         let mut result = Vec::new();
         self.available.retain(|chunk| {
             if self.desired.contains(chunk) || self.locks.contains_key(chunk) {
@@ -93,6 +167,64 @@ impl State {
             }
         });
         result
+    }
+
+    /// Whether an over-the-floor `batch` may go through this pass (REQ-25).
+    fn authorize(&mut self, batch: ChunkSet, now: Instant) -> bool {
+        match self.deletion_hold.take() {
+            // Already earned, and nothing new joined: let the remainder through.
+            Some(DeletionHold::Authorized { batch: earned }) if batch.is_subset(&earned) => {
+                self.deletion_hold = Some(DeletionHold::Authorized { batch: earned });
+                true
+            }
+            Some(DeletionHold::Holding { batch: held, since }) if held == batch => {
+                let held_for = now.duration_since(since);
+                if held_for < self.deletion_floor.hold_max {
+                    self.deletion_hold = Some(DeletionHold::Holding { batch: held, since });
+                    return false;
+                }
+                // Stood the whole window, so it is the network's intent, not a glitch.
+                warn!(
+                    "Deletion hold stood for {held_for:?}; evicting {} chunks",
+                    batch.len()
+                );
+                self.deletion_hold = Some(DeletionHold::Authorized { batch });
+                true
+            }
+            _ => {
+                warn!(
+                    "Holding eviction of {} of {} chunks: one assignment may not delete more \
+                     than the deletion floor (REQ-25). It goes through in {:?} unless an \
+                     assignment brings the batch back under the floor.",
+                    batch.len(),
+                    self.available.len(),
+                    self.deletion_floor.hold_max
+                );
+                self.deletion_hold = Some(DeletionHold::Holding { batch, since: now });
+                false
+            }
+        }
+    }
+
+    /// How many evictions the P-DEL-FLOOR gate is currently withholding, if any.
+    pub fn deletion_hold(&self) -> Option<usize> {
+        match &self.deletion_hold {
+            Some(DeletionHold::Holding { batch, .. }) => Some(batch.len()),
+            _ => None,
+        }
+    }
+
+    /// How long until the hold lapses. LIV-4 wants the eviction without a further input
+    /// event, so the reconciliation loop wakes itself on this.
+    pub fn deletion_hold_remaining(&self, now: Instant) -> Option<Duration> {
+        match &self.deletion_hold {
+            Some(DeletionHold::Holding { since, .. }) => Some(
+                self.deletion_floor
+                    .hold_max
+                    .saturating_sub(now.duration_since(*since)),
+            ),
+            _ => None,
+        }
     }
 
     // Only works as a hint to speed up things.
@@ -114,6 +246,23 @@ impl State {
         } else if self.desired.contains(&chunk) {
             self.to_download.insert(chunk);
         }
+    }
+
+    /// A chunk whose download address didn't resolve: back to pending for a later retry, and
+    /// recorded so the alarm can name the condition (FM-11).
+    pub fn defer_unresolvable(&mut self, chunk: ChunkRef) {
+        self.complete_download(&chunk, false);
+        self.unresolvable.insert(chunk);
+    }
+
+    pub fn unresolvable_chunks(&self) -> usize {
+        self.unresolvable.len()
+    }
+
+    /// Forgets which addresses didn't resolve, reporting whether there were any. The verdicts
+    /// belong to the document that produced them.
+    pub fn clear_unresolvable(&mut self) -> bool {
+        !std::mem::take(&mut self.unresolvable).is_empty()
     }
 
     #[cfg(any(feature = "mvcc-chunks", test))]
@@ -187,9 +336,23 @@ mod tests {
 
     use itertools::Itertools;
 
+    use std::time::{Duration, Instant};
+
     use crate::types::state::ChunkRef;
 
-    use super::State;
+    use super::{DeletionFloor, State};
+
+    /// Four chunks named in sort order, so a slice of the source vec is the expected batch.
+    fn store(n: usize) -> (Vec<ChunkRef>, Arc<String>) {
+        let ds = Arc::new("ds".to_owned());
+        let chunks = (0..n)
+            .map(|x| ChunkRef {
+                dataset: ds.clone(),
+                chunk: Arc::from(format!("000000000{x}")),
+            })
+            .collect();
+        (chunks, ds)
+    }
 
     #[test]
     fn test_state() {
@@ -207,15 +370,19 @@ mod tests {
         let c = chunk_ref(2);
         let d = chunk_ref(3);
 
-        let mut state = State::new([a.clone(), b.clone()].into_iter().collect());
+        let now = Instant::now();
+        let mut state = State::new(
+            [a.clone(), b.clone()].into_iter().collect(),
+            DeletionFloor::default(),
+        );
         state.set_desired_chunks([a.clone(), b.clone(), c.clone()].into_iter().collect());
         assert_eq!(state.take_next_download(), Some(c.clone()));
         assert_eq!(state.take_next_download(), None);
 
         state.set_desired_chunks([b.clone(), d.clone()].into_iter().collect());
         assert_eq!(state.get_stale_downloads(), &[c.clone()]);
-        assert_eq!(state.take_removals(), &[a.clone()]);
-        assert_eq!(state.take_removals(), &[]);
+        assert_eq!(state.take_removals(now), &[a.clone()]);
+        assert_eq!(state.take_removals(now), &[]);
         assert_eq!(state.get_stale_downloads(), &[c.clone()]);
 
         assert_eq!(state.take_next_download(), Some(d.clone()));
@@ -249,7 +416,11 @@ mod tests {
         let b = chunk_ref(1);
         let c = chunk_ref(2);
 
-        let mut state = State::new([a.clone(), b.clone()].into_iter().collect());
+        let now = Instant::now();
+        let mut state = State::new(
+            [a.clone(), b.clone()].into_iter().collect(),
+            DeletionFloor::default(),
+        );
         assert!(state.is_fully_applied());
 
         state.set_desired_chunks([a.clone(), b.clone(), c.clone()].into_iter().collect());
@@ -264,8 +435,162 @@ mod tests {
         state.set_desired_chunks([b.clone(), c.clone()].into_iter().collect());
         assert!(state.is_fully_applied());
 
-        assert_eq!(state.take_removals(), &[a]);
+        assert_eq!(state.take_removals(now), &[a]);
         assert!(state.is_fully_applied());
+    }
+
+    /// REQ-25: an assignment that drops everything must leave the store intact, and a
+    /// restoring one must resume normal eviction.
+    #[test]
+    fn deletion_floor_holds_a_wipe_and_releases_on_recovery() {
+        let (chunks, _ds) = store(4);
+        let now = Instant::now();
+        let mut state = State::new(chunks.iter().cloned().collect(), DeletionFloor::default());
+
+        // An empty slice would evict all four.
+        state.set_desired_chunks(Default::default());
+        assert_eq!(state.take_removals(now), &[]);
+        assert_eq!(state.deletion_hold(), Some(4));
+
+        // The hold is re-evaluated, not latched: it survives another pass...
+        assert_eq!(state.take_removals(now), &[]);
+        assert_eq!(state.deletion_hold(), Some(4));
+
+        // ...and lifts as soon as an assignment brings the batch back under the floor.
+        state.set_desired_chunks(chunks[..2].iter().cloned().collect());
+        assert_eq!(state.take_removals(now), &chunks[2..]);
+        assert_eq!(state.deletion_hold(), None);
+        assert_eq!(state.status().available.len(), 2);
+    }
+
+    /// The hold is a delay, not a veto: a shrink the network keeps republishing is its
+    /// intent, and obeying it late is what keeps RS-3 and LIV-4 bounded.
+    #[test]
+    fn deletion_hold_lapses_and_lets_a_persistent_shrink_through() {
+        let (chunks, _ds) = store(4);
+        let window = Duration::from_secs(3600);
+        let t0 = Instant::now();
+        let mut state = State::new(
+            chunks.iter().cloned().collect(),
+            DeletionFloor::new(0.5, window),
+        );
+
+        state.set_desired_chunks(Default::default());
+        assert_eq!(state.take_removals(t0), &[]);
+        assert_eq!(state.deletion_hold_remaining(t0), Some(window));
+
+        // Still held one second short of the window — and the clock runs from the first
+        // hold, not from the last pass.
+        let almost = t0 + window - Duration::from_secs(1);
+        assert_eq!(state.take_removals(almost), &[]);
+        assert_eq!(
+            state.deletion_hold_remaining(almost),
+            Some(Duration::from_secs(1))
+        );
+
+        assert_eq!(state.take_removals(t0 + window), chunks);
+        assert_eq!(state.deletion_hold(), None);
+        assert_eq!(state.deletion_hold_remaining(t0 + window), None);
+    }
+
+    /// The window is evidence about one batch, so a different wipe cannot inherit it — else a
+    /// second bad document arriving near expiry executes with no delay at all.
+    #[test]
+    fn a_different_batch_earns_its_own_window() {
+        let (chunks, _ds) = store(4);
+        let window = Duration::from_secs(3600);
+        let t0 = Instant::now();
+        let mut state = State::new(
+            chunks.iter().cloned().collect(),
+            DeletionFloor::new(0.5, window),
+        );
+
+        state.set_desired_chunks(Default::default());
+        assert_eq!(state.take_removals(t0), &[]);
+
+        // A second wipe-inducing assignment, one second before the first would have lapsed.
+        let late = t0 + window - Duration::from_secs(1);
+        state.set_desired_chunks(chunks[..1].iter().cloned().collect());
+        assert_eq!(state.take_removals(late), &[]);
+        assert_eq!(
+            state.take_removals(t0 + window),
+            &[],
+            "the new batch must not inherit the old one's window"
+        );
+        assert_eq!(state.take_removals(late + window), &chunks[1..]);
+    }
+
+    /// A pinned member of an authorized batch was already covered by that batch's window.
+    /// Making it wait another one would double LIV-4's bound.
+    #[test]
+    fn an_authorized_batch_does_not_earn_its_window_twice() {
+        let (chunks, _ds) = store(4);
+        let window = Duration::from_secs(3600);
+        let t0 = Instant::now();
+        let mut state = State::new(
+            chunks.iter().cloned().collect(),
+            DeletionFloor::new(0.5, window),
+        );
+        state.get_and_lock_chunk(chunks[3].dataset.clone(), chunks[3].chunk.clone());
+
+        state.set_desired_chunks(Default::default());
+        assert_eq!(state.take_removals(t0), &[]);
+        assert_eq!(state.take_removals(t0 + window), &chunks[..3]);
+
+        state.unlock_chunk(&chunks[3]);
+        assert_eq!(state.take_removals(t0 + window), &chunks[3..]);
+    }
+
+    /// A pin must not buy a wipe an instalment plan: pinned chunks count toward the batch, or
+    /// half the store goes now and the rest as each pin drops — 75 % of it under a 50 % floor.
+    #[test]
+    fn a_pin_does_not_let_a_wipe_past_the_floor() {
+        let (chunks, _ds) = store(4);
+        let now = Instant::now();
+        let mut state = State::new(chunks.iter().cloned().collect(), DeletionFloor::default());
+        for chunk in &chunks[..2] {
+            state.get_and_lock_chunk(chunk.dataset.clone(), chunk.chunk.clone());
+        }
+
+        state.set_desired_chunks(Default::default());
+        assert_eq!(state.take_removals(now), &[]);
+        assert_eq!(state.deletion_hold(), Some(4));
+
+        // Releasing a pin changes what is evictable, not what the assignment dropped.
+        state.unlock_chunk(&chunks[0]);
+        assert_eq!(state.take_removals(now), &[]);
+        assert_eq!(state.deletion_hold(), Some(4));
+        assert_eq!(state.status().available.len(), 4);
+    }
+
+    /// The pin still decides *when* a permitted removal runs (RS-2: pin > assignment).
+    #[test]
+    fn a_pin_defers_a_removal_the_floor_permits() {
+        let (chunks, _ds) = store(4);
+        let now = Instant::now();
+        let mut state = State::new(chunks.iter().cloned().collect(), DeletionFloor::default());
+        state.get_and_lock_chunk(chunks[3].dataset.clone(), chunks[3].chunk.clone());
+
+        // One of four dropped is well under the floor, but it is pinned.
+        state.set_desired_chunks(chunks[..3].iter().cloned().collect());
+        assert_eq!(state.take_removals(now), &[]);
+        assert_eq!(state.deletion_hold(), None, "permitted, merely deferred");
+
+        state.unlock_chunk(&chunks[3]);
+        assert_eq!(state.take_removals(now), &chunks[3..]);
+    }
+
+    /// The operator override (a floor of 1) turns the gate off entirely.
+    #[test]
+    fn deletion_floor_of_one_permits_a_full_wipe() {
+        let (chunks, _ds) = store(4);
+        let mut state = State::new(
+            chunks.iter().cloned().collect(),
+            DeletionFloor::new(1.0, Duration::from_secs(3600)),
+        );
+        state.set_desired_chunks(Default::default());
+        assert_eq!(state.take_removals(Instant::now()).len(), 4);
+        assert_eq!(state.deletion_hold(), None);
     }
 
     #[test]
@@ -283,7 +608,10 @@ mod tests {
         let b = chunk_ref(1);
         let c = chunk_ref(2);
 
-        let mut state = State::new([a.clone(), b.clone()].into_iter().collect());
+        let mut state = State::new(
+            [a.clone(), b.clone()].into_iter().collect(),
+            DeletionFloor::default(),
+        );
         state.set_desired_chunks([a.clone(), b.clone(), c.clone()].into_iter().collect());
 
         assert_eq!(state.take_next_download(), Some(c.clone()));

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,9 +1,11 @@
 pub mod hash;
 pub mod iterator;
 mod once;
+mod panic;
 #[cfg(test)]
 pub mod tests;
 pub mod timestamp;
 
 pub type UseOnce<T> = once::UseOnce<T>;
+pub use panic::panic_message;
 pub use timestamp::timestamp_now_ms;

--- a/src/util/panic.rs
+++ b/src/util/panic.rs
@@ -1,0 +1,25 @@
+/// The message a caught panic carried, for the typed error replacing it (ADR-5, ADR-21).
+/// By value: `&Box<dyn Any>` unsizes to the box, not its contents, so every downcast misses.
+pub fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+    payload
+        .downcast_ref::<&str>()
+        .map(|s| s.to_string())
+        .or_else(|| payload.downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "unknown panic".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::panic_message;
+
+    #[test]
+    fn reads_both_payload_shapes_and_neither() {
+        let caught = |f: fn()| match std::panic::catch_unwind(f) {
+            Ok(()) => unreachable!("the closure panics"),
+            Err(payload) => panic_message(payload),
+        };
+        assert_eq!(caught(|| panic!("static")), "static");
+        assert_eq!(caught(|| panic!("{}", "owned".to_string())), "owned");
+        assert_eq!(caught(|| std::panic::panic_any(7u8)), "unknown panic");
+    }
+}

--- a/tests/assignment_faults.rs
+++ b/tests/assignment_faults.rs
@@ -1,0 +1,290 @@
+//! CT-4 input-fault corpus, assignment side: what a hostile or merely wrong document may do
+//! to a running worker (REQ-24, FM-1, FM-11/12/13/52, REQ-25).
+//!
+//! Part of the conformance tier (spec/13). Run the whole tier with
+//! `cargo test --test e2e --test query_surface --test query_concurrency
+//! --test assignment_faults`. A failure prints the run seed; replay with
+//! `SQD_CONFORMANCE_SEED=0x…`.
+
+mod harness;
+
+use std::time::Duration;
+
+use harness::scheduler::AssignmentFault;
+use harness::{corpus, validators, Config, Harness};
+use sqd_messages::query_result;
+
+/// FM-11: one unusable address costs one chunk. The rest of the document applies and the
+/// worker keeps serving. The panic this replaces was a whole-process outage under ADR-14.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_bad_chunk_address_costs_that_chunk_only() {
+    let mut h = Harness::start().await;
+
+    // The knob corrupts the first placement's base address.
+    let broken = corpus::chunk(1_000, 1_009, 1);
+    let sound = corpus::chunk(1_010, 1_019, 1);
+    let placements = [h.host_chunk(&broken), h.host_chunk(&sound)];
+    h.publish(
+        "assignment-1",
+        &placements,
+        AssignmentFault::UnparseableFileUrl,
+    );
+    assert!(
+        h.poll_and_apply().await,
+        "FM-11: a per-chunk defect must not reject the document"
+    );
+
+    // The sound chunk converges: the loop is alive and the rest of the slice applied.
+    h.await_condition("the sound chunk becomes available", || async {
+        let status = h.worker.status().await;
+        status.unavailability_map.len() == 2 && !status.unavailability_map[1]
+    })
+    .await;
+
+    h.await_condition("the bad address is alarmed", || async {
+        h.worker.alarms().unresolvable_chunks > 0
+    })
+    .await;
+
+    let status = h.status().await;
+    assert!(
+        status.missing_chunks.as_ref().unwrap().ones() == 1,
+        "FM-3: exactly one chunk may be lost to one bad address"
+    );
+    validators::status(&status, 2).assert_none("status with one unresolvable chunk");
+    assert_eq!(
+        h.origin.fetch_count(&broken.id, "blocks.parquet"),
+        0,
+        "an address that doesn't parse cannot have been fetched"
+    );
+
+    // REQ-24: the chunk that did arrive still answers queries.
+    let query = h.all_blocks_query(&sound.id, (1_010, 1_019));
+    let served = h.serve(query.clone()).await;
+    let (response, _) = served.expect_admitted();
+    validators::query_response(response, &query, h.worker_id).assert_none("query after the fault");
+    assert!(
+        matches!(response.result, Some(query_result::Result::Ok(_))),
+        "the sound chunk must still be queryable, got {:?}",
+        response.result
+    );
+
+    // A degrade, not a quarantine: a document that fixes the address converges.
+    let placements = [h.host_chunk(&broken), h.host_chunk(&sound)];
+    h.publish_and_apply("assignment-2", &placements).await;
+    h.await_all_chunks_available().await;
+    assert_eq!(
+        h.worker.alarms().unresolvable_chunks,
+        0,
+        "the alarm must clear once the addresses resolve"
+    );
+}
+
+/// FM-12: a roster entry the reader can't parse rejects the document. The reader panics on
+/// it, and that panic must cost one document, not the process (FM-1).
+#[tokio::test(flavor = "multi_thread")]
+async fn an_unparseable_roster_entry_rejects_the_document() {
+    let mut h = Harness::start().await;
+
+    let chunk = corpus::chunk(2_000, 2_009, 1);
+    let placement = h.host_chunk(&chunk);
+    let good = h
+        .publish_and_apply("assignment-1", std::slice::from_ref(&placement))
+        .await;
+    h.await_all_chunks_available().await;
+
+    h.publish(
+        "assignment-2",
+        std::slice::from_ref(&placement),
+        AssignmentFault::CorruptRosterPeerId,
+    );
+    assert!(
+        !h.poll_and_apply().await,
+        "FM-12: a document whose roster can't be read must be rejected"
+    );
+
+    // WP-2: rejection changes nothing.
+    let status = h.status().await;
+    assert_eq!(
+        status.assignment_id, good.id,
+        "WP-2: prior assignment holds"
+    );
+    validators::status(&status, 1).assert_none("status after a rejected document");
+
+    let query = h.all_blocks_query(&chunk.id, (2_000, 2_009));
+    let served = h.serve(query.clone()).await;
+    let (response, _) = served.expect_admitted();
+    validators::query_response(response, &query, h.worker_id)
+        .assert_none("query after a rejected document");
+    assert!(
+        matches!(response.result, Some(query_result::Result::Ok(_))),
+        "REQ-24: the worker must keep serving, got {:?}",
+        response.result
+    );
+
+    // And a readable document still applies afterwards.
+    let next = h.publish_and_apply("assignment-3", &[placement]).await;
+    assert_eq!(h.status().await.assignment_id, next.id);
+}
+
+/// REQ-25 / FM-13: an assignment that drops everything is held, not obeyed. Otherwise a
+/// scheduler bug wipes a multi-terabyte store in one pass.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_empty_slice_cannot_wipe_the_store() {
+    let mut h = Harness::start().await;
+
+    let chunks: Vec<_> = (0..4)
+        .map(|i| corpus::chunk(5_000 + i * 10, 5_009 + i * 10, 1))
+        .collect();
+    let placements: Vec<_> = chunks.iter().map(|c| h.host_chunk(c)).collect();
+    h.publish_and_apply("assignment-1", &placements).await;
+    h.await_all_chunks_available().await;
+
+    // 4 of 4 stored chunks would go, well past P-DEL-FLOOR.
+    h.publish(
+        "assignment-2",
+        &placements,
+        AssignmentFault::NoChunksForWorker,
+    );
+    assert!(h.poll_and_apply().await, "the document is well-formed");
+
+    h.await_condition("the deletion floor holds the batch", || async {
+        h.worker.alarms().deletion_hold.is_some()
+    })
+    .await;
+    assert_eq!(h.worker.alarms().deletion_hold, Some(4));
+
+    // Still there, and still serving: eviction is what makes a chunk unavailable, not the
+    // assignment.
+    for chunk in &chunks {
+        assert!(
+            h.chunk_dir(&chunk.id).exists(),
+            "REQ-25: {} was deleted by a wipe-inducing assignment",
+            chunk.id
+        );
+    }
+    let query = h.all_blocks_query(&chunks[0].id, (5_000, 5_009));
+    let served = h.serve(query.clone()).await;
+    let (response, _) = served.expect_admitted();
+    validators::query_response(response, &query, h.worker_id).assert_none("query under the hold");
+    assert!(
+        matches!(response.result, Some(query_result::Result::Ok(_))),
+        "held data must still serve, got {:?}",
+        response.result
+    );
+
+    // A restoring assignment brings the batch under the floor: 1 of 4 is 25 %.
+    h.publish_and_apply("assignment-3", &placements[..3]).await;
+    h.await_condition("the released eviction completes", || async {
+        !h.chunk_dir(&chunks[3].id).exists()
+    })
+    .await;
+    assert_eq!(
+        h.worker.alarms().deletion_hold,
+        None,
+        "the hold must lift once the batch is under the floor"
+    );
+    for chunk in &chunks[..3] {
+        assert!(h.chunk_dir(&chunk.id).exists(), "{} evicted", chunk.id);
+    }
+}
+
+/// LIV-4: the hold is a delay, not a veto. Nothing happens after the wipe-inducing document
+/// lands — no new assignment, no download — so the eviction has to come off the hold's own
+/// timer, which is what LIV-4's "without requiring any further input event" demands.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_persistent_wipe_goes_through_when_the_hold_lapses() {
+    let mut h = Harness::with_config(Config {
+        deletion_hold_max: Duration::from_millis(300),
+        ..Default::default()
+    })
+    .await;
+
+    let chunks: Vec<_> = (0..4)
+        .map(|i| corpus::chunk(7_000 + i * 10, 7_009 + i * 10, 1))
+        .collect();
+    let placements: Vec<_> = chunks.iter().map(|c| h.host_chunk(c)).collect();
+    h.publish_and_apply("assignment-1", &placements).await;
+    h.await_all_chunks_available().await;
+
+    h.publish(
+        "assignment-2",
+        &placements,
+        AssignmentFault::NoChunksForWorker,
+    );
+    assert!(h.poll_and_apply().await);
+
+    h.await_condition("the hold lapses and the store drains", || async {
+        chunks.iter().all(|c| !h.chunk_dir(&c.id).exists())
+    })
+    .await;
+    assert_eq!(h.worker.alarms().deletion_hold, None);
+}
+
+/// ADR-17's override: a sanctioned rebalance sets the floor to 1 and gets the old behavior.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_floor_override_permits_a_full_rebalance() {
+    let mut h = Harness::with_config(Config {
+        deletion_floor: 1.0,
+        ..Default::default()
+    })
+    .await;
+
+    let chunk = corpus::chunk(6_000, 6_009, 1);
+    let placement = h.host_chunk(&chunk);
+    h.publish_and_apply("assignment-1", std::slice::from_ref(&placement))
+        .await;
+    h.await_all_chunks_available().await;
+
+    h.publish(
+        "assignment-2",
+        &[placement],
+        AssignmentFault::NoChunksForWorker,
+    );
+    assert!(h.poll_and_apply().await);
+
+    h.await_condition("the chunk is evicted", || async {
+        !h.chunk_dir(&chunk.id).exists()
+    })
+    .await;
+    assert_eq!(h.worker.alarms().deletion_hold, None);
+}
+
+/// FM-52: the chain registry is down before the worker starts. Failing startup here turns a
+/// registry outage into a fleet outage.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_registry_outage_at_startup_degrades_instead_of_refusing_to_start() {
+    let mut h = Harness::with_config(Config {
+        registry_failure: Some("registry is down".to_owned()),
+        ..Default::default()
+    })
+    .await;
+
+    // The write path doesn't touch the registry: assignments apply, chunks converge.
+    let chunk = corpus::chunk(4_000, 4_009, 1);
+    let placement = h.host_chunk(&chunk);
+    h.publish_and_apply("assignment-1", &[placement]).await;
+    h.await_all_chunks_available().await;
+
+    // No allocation is known, so queries are refused rather than answered.
+    let query = h.all_blocks_query(&chunk.id, (4_000, 4_009));
+    let harness::Served::PreAdmission { reason, .. } = h.serve(query.clone()).await else {
+        panic!("with no known allocation a query cannot be admitted");
+    };
+    assert!(
+        matches!(reason, sqd_messages::query_error::Err::TooManyRequests(())),
+        "RP-20: expected the no-allocation rejection, got {reason:?}"
+    );
+
+    // ...and recover once the registry answers again.
+    h.registry.heal();
+    h.await_metering_ready().await;
+    let served = h.serve(query.clone()).await;
+    let (response, _) = served.expect_admitted();
+    validators::query_response(response, &query, h.worker_id).assert_none("query after recovery");
+    assert!(
+        matches!(response.result, Some(query_result::Result::Ok(_))),
+        "the worker must serve once the registry recovers, got {:?}",
+        response.result
+    );
+}

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -129,6 +129,12 @@ pub struct Config {
     pub compute_units: u64,
     pub download_backoff_max: Duration,
     pub file_timeout: Duration,
+    /// P-DEL-FLOOR (REQ-25).
+    pub deletion_floor: f64,
+    /// P-DEL-HOLD-MAX: how long the floor withholds a batch before it goes through.
+    pub deletion_hold_max: Duration,
+    /// HC-8 fails every read from before the worker starts (FM-52). Skips the metering wait.
+    pub registry_failure: Option<String>,
 }
 
 impl Default for Config {
@@ -141,6 +147,9 @@ impl Default for Config {
             // Shipped defaults are 300 s / 60 s — too long to wait on a provoked failure.
             download_backoff_max: Duration::from_millis(200),
             file_timeout: Duration::from_secs(5),
+            deletion_floor: 0.5,
+            deletion_hold_max: Duration::from_secs(3600),
+            registry_failure: None,
         }
     }
 }
@@ -164,6 +173,9 @@ impl Harness {
         let scheduler = Scheduler::start(seed.stream("assignment-builder")).await;
         let origin = Origin::start().await;
         let registry = Registry::new(&[portal.peer_id()], config.compute_units);
+        if let Some(failure) = &config.registry_failure {
+            registry.fail_reads(failure.clone());
+        }
 
         let schema_stub = HttpStub::start().await;
         schema_stub.put(
@@ -194,16 +206,12 @@ impl Harness {
             config.parallel_queries,
         ));
 
-        let allocations = Arc::new(
-            AllocationsChecker::new(
-                registry.client(),
-                worker_id,
-                // Fast enough that a test that advances the epoch doesn't wait on P-EPOCH-POLL.
-                Duration::from_millis(20),
-            )
-            .await
-            .expect("registry stub answers the worker-id lookup"),
-        );
+        let allocations = Arc::new(AllocationsChecker::new(
+            registry.client(),
+            worker_id,
+            // Fast enough that a test that advances the epoch doesn't wait on P-EPOCH-POLL.
+            Duration::from_millis(20),
+        ));
 
         let logs = LogsStorage::new(data_path.join("logs.db").as_str())
             .await
@@ -250,7 +258,9 @@ impl Harness {
             _reporter: reporter,
         };
         harness.await_schemas_loaded().await;
-        harness.await_metering_ready().await;
+        if config.registry_failure.is_none() {
+            harness.await_metering_ready().await;
+        }
         harness
     }
 
@@ -449,7 +459,7 @@ impl Harness {
 
     /// Waits until the portal's bucket holds a token, stepping over the cold-start window
     /// (LIV-12, GAP-25) so tests about anything else don't race it.
-    async fn await_metering_ready(&self) {
+    pub async fn await_metering_ready(&self) {
         let portal = self.portal.peer_id();
         self.await_condition("metering bucket funded (LIV-12)", || async move {
             // Probe and immediately put the token back, so readiness costs nothing.
@@ -562,6 +572,8 @@ fn build_args(
         &config.parallel_queries.to_string(),
         "--concurrent-downloads",
         &config.concurrent_downloads.to_string(),
+        "--deletion-floor",
+        &config.deletion_floor.to_string(),
         "--rpc-url",
         "http://127.0.0.1:1/unused",
         "--l1-rpc-url",
@@ -572,6 +584,7 @@ fn build_args(
     args.s3_timeout = config.file_timeout;
     args.s3_read_timeout = config.file_timeout;
     args.downloads_max_delay = config.download_backoff_max;
+    args.deletion_hold_max = config.deletion_hold_max;
     args.assignment_fetch_timeout = Duration::from_secs(10);
     args.assignment_fetch_max_delay = Duration::from_millis(200);
     args.sentry_is_enabled = false;
@@ -607,7 +620,7 @@ fn declared_gaps_cite_the_spec() {
     let defined = spec_identifiers();
     // An inventory that failed to load would make everything below vacuous.
     assert!(
-        defined.len() > 100 && defined.contains("GAP-3") && defined.contains("INV-31"),
+        defined.len() > 100 && defined.contains("GAP-4") && defined.contains("INV-31"),
         "spec inventory looks wrong — {} identifiers parsed out of spec/",
         defined.len()
     );

--- a/tests/harness/scheduler.rs
+++ b/tests/harness/scheduler.rs
@@ -22,10 +22,13 @@ const STORAGE_SECRET: &str = "conformance-storage-secret";
 pub enum AssignmentFault {
     #[default]
     None,
-    /// A chunk whose dataset base address doesn't parse — GAP-2's reconciler panic.
+    /// The **first** placement's base address doesn't parse (FM-11). Per-chunk on purpose:
+    /// the blast radius under test is one chunk, not the document.
     UnparseableFileUrl,
-    /// The worker is in the roster but holds no chunks — GAP-3's deletion floor.
+    /// The worker is in the roster but holds no chunks — REQ-25's deletion floor.
     NoChunksForWorker,
+    /// A roster entry whose peer id can't be parsed (FM-12). The reader panics on it.
+    CorruptRosterPeerId,
     /// Truncated gzip stream — FM-12 / GAP-4's unvalidated document.
     TruncatedDocument,
 }
@@ -156,7 +159,7 @@ impl Scheduler {
 
         let mut assigned_indexes = Vec::new();
         for (index, placement) in placements.iter().enumerate() {
-            let base_url = if fault == AssignmentFault::UnparseableFileUrl {
+            let base_url = if fault == AssignmentFault::UnparseableFileUrl && index == 0 {
                 "not a url"
             } else {
                 &placement.dataset_base_url
@@ -188,8 +191,23 @@ impl Scheduler {
             1_700_000_000,
         );
 
-        builder.finish()
+        let mut doc = builder.finish();
+        if fault == AssignmentFault::CorruptRosterPeerId {
+            corrupt_peer_id(&mut doc, worker);
+        }
+        doc
     }
+}
+
+/// Patching the encoded bytes is the only way in: the builder takes a parsed `PeerId`.
+fn corrupt_peer_id(doc: &mut [u8], worker: PeerId) {
+    let encoded = worker.to_bytes();
+    let at = doc
+        .windows(encoded.len())
+        .position(|w| w == encoded)
+        .expect("the roster carries the worker's peer id verbatim");
+    // Not a multihash code libp2p accepts; the 38-byte struct layout stays intact.
+    doc[at] = 0x01;
 }
 
 fn gzip(bytes: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
Closes the last two P0 rows in the spec/13 gap register. Both are remote-triggerable
by whoever publishes an assignment document.

## GAP-2 — externally supplied content could terminate the process

Under ADR-14's supervision tree any panic in a loop is a whole-process outage, so a
scheduler bug or a registry blip becomes a fleet outage. Four paths, one per subsystem:

| Path | Fix |
|---|---|
| A malformed file address panicked the reconciler | `list_files` returning `None` defers that chunk and alarms; the rest of the document applies (FM-11) |
| An unparseable roster peer id panicked the reader | `DatasetsIndex::new` is a panic-catching boundary (ADR-21) → the document is rejected whole (FM-12); the `spawn_blocking` join repeats the catch instead of `.expect`-ing |
| A pathological per-chunk file count overflowed the download watchdog | `watchdog_timeout` saturates, and a zero-file chunk gets one timeout instead of expiring immediately |
| A registry error at startup was fatal | `AllocationsChecker` resolves its on-chain id lazily in the polling loop and alarms while unresolved (FM-52) |

Deferred chunks are held out of the pending set only for the duration of a pass, so the
download loop still terminates, and applying a new index notifies the loop even when the
chunk set is unchanged — otherwise a repaired address would wait for an unrelated event.

## GAP-3 — no reconciliation deletion floor

Reconciliation deleted whatever the assignment stopped naming, so one short document
wiped a multi-terabyte store in a single pass. ADR-17 is ratified and implemented: an
application that would evict more than `P-DEL-FLOOR` (default 50 %, `--deletion-floor`)
of the stored chunks evicts none of them, raises an alarm, and re-runs the test every
pass, so a restoring assignment releases the hold by itself. Held data stays queryable.
The batch is held whole rather than trimmed to the bar, because trimming still wipes the
store, just over several passes.

**The hold is a bounded delay, not a veto.** An indefinite one breaks two MUSTs outright:
a withheld chunk meets LIV-4's precondition exactly (in the available set, not in the
assignment, unpinned) and never leaves, and its bytes belong to no term of RS-3's excess
bound. It also strands disk on a worker the network legitimately shrank — and since
eviction precedes fetching in the loop, a worker that cannot free space needs twice the
headroom to converge on a large rebalance. So the batch goes through after
`P-DEL-HOLD-MAX` (default 1 h, `DELETION_HOLD_MAX_SEC`), off a timer the reconciliation
loop owns, which is what LIV-4's "without requiring any further input event" demands.

What the window buys is machine self-correction, not human response: a scheduler glitch
is corrected by the next publication, while a real shrink keeps being republished for the
whole window, so the two separate themselves. A bug that outlives the window still wipes
— this guards against a glitch, not a sustained fault. Raising the floor to 1 is the
operator override.

The floor counts every chunk the assignment dropped, **pinned or not**. A pin lasts one
query, so letting it shrink the batch would deal a wipe out in instalments instead of
holding it. Pins keep deciding which permitted removals run now (RS-2 precedence).

Spec consequences recorded rather than hand-waved: RS-3 gains an explicit `H` term for
held bytes bounded by `P-DEL-HOLD-MAX`, LIV-4's bound becomes `P-DEL-HOLD-MAX +
P-EVICT-BOUND` for the hold path, and ADR-17 states plainly what the guard does not
cover.

## Alarms

Both closures needed somewhere to report, which is OB-12's first real binding:
`worker_alarms{reason}` plus a per-instance `Alarms` snapshot. The conformance tests
assert the instance state — the gauges are process-global and would race across tests.

## Testing

New `tests/assignment_faults.rs` (CT-4 assignment-fault corpus, wired into the CI
conformance job) with 7 tests; the unit tier grows to 47. Every fix was verified by
reverting it and confirming its test fails — including the hold's self-wake (the loop
hangs 30 s without the timer arm) and the pin-counting fix — so none of them pass
vacuously. Green on the unit tier, the conformance tier under both CI feature configs,
`cargo fmt`, the clippy gate, and `check_spec.py`.

## Judgment calls worth a look

- **The spec linter is tuned.** Closing a gap deletes its register row, but ADR-14 cites
  `GAP-2` and accepted ADRs are append-only, so the id dangles. `id-undefined` now exempts
  `decisions/` for the `GAP-` prefix, and only for ADRs whose status is `Accepted` —
  proposed ones stay checked, which is how ADR-18's now-stale claim about the reader panic
  got caught and corrected. The alternative is keeping closed rows with a status column.
- **A rejected document is not retried under the same assignment id** (pre-existing: the
  id is recorded before application). Every rejection cause is a property of the document
  bytes, so re-fetching identical bytes is waste, and acknowledging the id only on success
  would loop forever on a genuinely bad document — GAP-9's head-of-line blocking. Recovery
  is bounded by the next published id. Say the word if you want it tracked as a gap row.
- **The conformance job builds a 4th test binary** against the 10-minute `P-GATE-PR-TIME`
  timeout. The tests run in under a second; the cost is one more ~300 MB link per matrix
  config. The timeout is unchanged — worth watching on the first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)