### PR TITLE
feat(NET-1186): discover and parse the worker-oriented assignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7198,7 +7198,7 @@ dependencies = [
 [[package]]
 name = "sqd-assignments"
 version = "0.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=0633335#063333532d9dae3acfb28728118fa67c9e637486"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=1e334ec#1e334ec47b3ab3ed36213d108e615627db7e5be8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7198,7 +7198,7 @@ dependencies = [
 [[package]]
 name = "sqd-assignments"
 version = "0.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=032d0c5#032d0c58aa1e36a0ca35a632e831fb16ee010081"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=360bbd4#360bbd4f115b44733dbfbf169bd5011f74cecb65"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5833,7 +5833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.10.5",
  "log",
  "multimap",
@@ -5853,7 +5853,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.10.5",
  "log",
  "multimap",
@@ -7198,7 +7198,7 @@ dependencies = [
 [[package]]
 name = "sqd-assignments"
 version = "0.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=1e334ec#1e334ec47b3ab3ed36213d108e615627db7e5be8"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=032d0c5#032d0c58aa1e36a0ca35a632e831fb16ee010081"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,9 +65,7 @@ url = "2.5.2"
 walkdir = "2.5.0"
 zstd = "0.13"
 
-# TEMPORARY: pinned to the unmerged NET-1180 branch (WorkerAssignment/PortalAssignment types) for
-# NET-1186. Re-pin to sqd-network's master once NET-1180 lands there.
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "032d0c5", features = ["reader"] }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "360bbd4", features = ["reader"] }
 sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "0633335", version = "1.2.1" }
 sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "0633335", version = "2.0.2", features = ["bitstring"] }
 sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "0633335", version = "3.0.0", features = ["worker", "metrics"] }
@@ -84,8 +82,7 @@ arrow = "54.2.1"
 # implements its `Client` trait, whose signatures mention `Ratio<u128>`.
 num-rational = "0.4"
 parquet = { version = "54.2.1", features = ["arrow"] }
-# TEMPORARY: see the NET-1180 note on the [dependencies] sqd-assignments entry above.
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "032d0c5", features = ["builder"] }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "360bbd4", features = ["builder"] }
 tempfile = "3"
 
 # sqd-network-transport depends on the kalabukdima/rust-libp2p fork, whose crates build against their

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ zstd = "0.13"
 
 # TEMPORARY: pinned to the unmerged NET-1180 branch (WorkerAssignment/PortalAssignment types) for
 # NET-1186. Re-pin to sqd-network's master once NET-1180 lands there.
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "1e334ec", features = ["reader"] }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "032d0c5", features = ["reader"] }
 sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "0633335", version = "1.2.1" }
 sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "0633335", version = "2.0.2", features = ["bitstring"] }
 sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "0633335", version = "3.0.0", features = ["worker", "metrics"] }
@@ -85,7 +85,7 @@ arrow = "54.2.1"
 num-rational = "0.4"
 parquet = { version = "54.2.1", features = ["arrow"] }
 # TEMPORARY: see the NET-1180 note on the [dependencies] sqd-assignments entry above.
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "1e334ec", features = ["builder"] }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "032d0c5", features = ["builder"] }
 tempfile = "3"
 
 # sqd-network-transport depends on the kalabukdima/rust-libp2p fork, whose crates build against their

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [features]
 query-tracing = ["sqd-query/max_level_trace"]
-mvcc-chunks = []
+mvcc-chunks = ["sqd-assignments/mvcc-chunks"]
 
 [dependencies]
 anyhow = "1.0"
@@ -65,7 +65,9 @@ url = "2.5.2"
 walkdir = "2.5.0"
 zstd = "0.13"
 
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "0633335", features = ["reader"] }
+# TEMPORARY: pinned to the unmerged NET-1180 branch (WorkerAssignment/PortalAssignment types) for
+# NET-1186. Re-pin to sqd-network's master once NET-1180 lands there.
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "1e334ec", features = ["reader"] }
 sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "0633335", version = "1.2.1" }
 sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "0633335", version = "2.0.2", features = ["bitstring"] }
 sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "0633335", version = "3.0.0", features = ["worker", "metrics"] }
@@ -82,7 +84,8 @@ arrow = "54.2.1"
 # implements its `Client` trait, whose signatures mention `Ratio<u128>`.
 num-rational = "0.4"
 parquet = { version = "54.2.1", features = ["arrow"] }
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "0633335", features = ["builder"] }
+# TEMPORARY: see the NET-1180 note on the [dependencies] sqd-assignments entry above.
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "1e334ec", features = ["builder"] }
 tempfile = "3"
 
 # sqd-network-transport depends on the kalabukdima/rust-libp2p fork, whose crates build against their

--- a/src/controller/assignments.rs
+++ b/src/controller/assignments.rs
@@ -10,6 +10,10 @@ pub struct AssignmentUpdate {
     pub id: String,
     pub fb_url_v1: String,
     pub _effective_from: u64,
+    /// Whether this update was discovered via the dedicated `worker_assignment` pointer rather
+    /// than the legacy shared `assignment` (NET-1186). Always `false` outside `mvcc-chunks`.
+    #[cfg(feature = "mvcc-chunks")]
+    pub is_worker_assignment: bool,
 }
 
 pub fn new_reqwest_client(timeout: Duration, peer_id: PeerId) -> reqwest::Client {
@@ -67,16 +71,19 @@ async fn update_assignment(
 ) -> anyhow::Result<Option<AssignmentUpdate>> {
     tracing::debug!("Checking for new assignment: {url}");
     let network_state = fetch_network_state(&url, &reqwest_client).await?;
-    let assignment_id = network_state.assignment.id;
+    #[cfg_attr(not(feature = "mvcc-chunks"), allow(unused_variables))]
+    let (visible, is_worker_assignment) = visible_assignment(&network_state);
+    let assignment_id = visible.id.clone();
     if last_id.as_ref() == Some(&assignment_id) {
         tracing::debug!("Assignment has not been changed");
         return anyhow::Ok(None);
     }
 
-    let fb_url_v1 = network_state
-        .assignment
+    let fb_url_v1 = visible
         .fb_url_v1
+        .clone()
         .ok_or_else(|| anyhow::anyhow!("Missing fb_url_v1"))?;
+    let _effective_from = visible.effective_from;
     *last_id = Some(assignment_id.clone());
 
     tracing::debug!("Discovered assignment \"{}\"", assignment_id);
@@ -84,8 +91,37 @@ async fn update_assignment(
     Ok(Some(AssignmentUpdate {
         id: assignment_id,
         fb_url_v1,
-        _effective_from: network_state.assignment.effective_from,
+        _effective_from,
+        #[cfg(feature = "mvcc-chunks")]
+        is_worker_assignment,
     }))
+}
+
+/// Selects the assignment pointer to discover updates from.
+///
+/// `mvcc-chunks` builds prefer the dedicated `worker_assignment` pointer but fall back to the
+/// legacy `assignment` so rollouts tolerate a scheduler that hasn't started publishing
+/// `worker_assignment` yet — mirrors sqd-portal's `visible_assignment` (NET-1186). Non-`mvcc-chunks`
+/// builds always use the legacy pointer; there is no other concept of assignment to prefer.
+fn visible_assignment(
+    network_state: &sqd_assignments::NetworkState,
+) -> (&sqd_assignments::NetworkAssignment, bool) {
+    #[cfg(feature = "mvcc-chunks")]
+    {
+        match network_state.worker_assignment.as_ref() {
+            Some(assignment) => (assignment, true),
+            None => {
+                tracing::debug!(
+                    "worker_assignment missing in network state; falling back to legacy assignment"
+                );
+                (&network_state.assignment, false)
+            }
+        }
+    }
+    #[cfg(not(feature = "mvcc-chunks"))]
+    {
+        (&network_state.assignment, false)
+    }
 }
 
 async fn fetch_network_state(
@@ -101,6 +137,23 @@ pub async fn fetch_assignment(
     url: &str,
     reqwest_client: &reqwest::Client,
 ) -> anyhow::Result<sqd_assignments::Assignment> {
+    let buf = download_gzipped(url, reqwest_client).await?;
+    Ok(sqd_assignments::Assignment::from_owned_unchecked(buf))
+}
+
+/// Decodes the dedicated worker-oriented assignment (NET-1186). Parsing only — wiring the result
+/// into `DatasetsIndex`/serving state is out of scope until schema delivery exists (there is
+/// nothing to derive a `WorkerAssignmentChunk`'s files from yet).
+#[cfg(feature = "mvcc-chunks")]
+pub async fn fetch_worker_assignment(
+    url: &str,
+    reqwest_client: &reqwest::Client,
+) -> anyhow::Result<sqd_assignments::WorkerAssignment> {
+    let buf = download_gzipped(url, reqwest_client).await?;
+    Ok(sqd_assignments::WorkerAssignment::from_owned_unchecked(buf))
+}
+
+async fn download_gzipped(url: &str, reqwest_client: &reqwest::Client) -> anyhow::Result<Vec<u8>> {
     use async_compression::tokio::bufread::GzipDecoder;
     use futures::TryStreamExt;
     use tokio::io::AsyncReadExt;
@@ -115,5 +168,55 @@ pub async fn fetch_assignment(
         .read_to_end(&mut buf)
         .await
         .map_err(|e| anyhow::anyhow!("Failed to download assignment: {}", e))?;
-    Ok(sqd_assignments::Assignment::from_owned_unchecked(buf))
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(deprecated)]
+    fn assignment(id: &str) -> sqd_assignments::NetworkAssignment {
+        sqd_assignments::NetworkAssignment {
+            url: None,
+            fb_url: None,
+            fb_url_v1: Some(format!("https://example.test/{id}.fb.gz")),
+            id: id.to_string(),
+            effective_from: 123,
+        }
+    }
+
+    fn network_state() -> sqd_assignments::NetworkState {
+        sqd_assignments::NetworkState {
+            network: "testnet".to_string(),
+            assignment: assignment("legacy"),
+            #[cfg(feature = "mvcc-chunks")]
+            worker_assignment: None,
+            #[cfg(feature = "mvcc-chunks")]
+            portal_assignment: None,
+        }
+    }
+
+    #[test]
+    fn visible_assignment_uses_legacy_assignment() {
+        let state = network_state();
+        let (visible, is_worker_assignment) = visible_assignment(&state);
+
+        assert_eq!(visible.id, "legacy");
+        #[cfg(feature = "mvcc-chunks")]
+        assert!(!is_worker_assignment);
+        #[cfg(not(feature = "mvcc-chunks"))]
+        let _ = is_worker_assignment;
+    }
+
+    #[cfg(feature = "mvcc-chunks")]
+    #[test]
+    fn visible_assignment_prefers_worker_assignment() {
+        let mut state = network_state();
+        state.worker_assignment = Some(assignment("worker"));
+
+        let (visible, is_worker_assignment) = visible_assignment(&state);
+        assert_eq!(visible.id, "worker");
+        assert!(is_worker_assignment);
+    }
 }

--- a/src/controller/p2p.rs
+++ b/src/controller/p2p.rs
@@ -292,6 +292,33 @@ impl<EventStream: Stream<Item = WorkerEvent> + Send + 'static> P2PController<Eve
         'assignments: loop {
             if processing_id.is_none() {
                 if let Some(update) = pending.pop_front() {
+                    // NET-1186: decode-only for now — DatasetsIndex/serving still needs the
+                    // legacy format (WorkerAssignmentChunk has no files/base_url; deriving them
+                    // from schema_id/tables_present is separate, not-yet-scoped work). Discarding
+                    // this update rather than falling back to `fetch_assignment` avoids feeding
+                    // worker-assignment-format bytes to the legacy parser.
+                    #[cfg(feature = "mvcc-chunks")]
+                    if update.is_worker_assignment {
+                        match super::assignments::fetch_worker_assignment(
+                            &update.fb_url_v1,
+                            &assignment_client,
+                        )
+                        .await
+                        {
+                            Ok(assignment) => {
+                                tracing::info!(
+                                    assignment_id = %update.id,
+                                    datasets = assignment.datasets().len(),
+                                    "Decoded worker-oriented assignment (not yet applied to serving state)"
+                                );
+                            }
+                            Err(e) => {
+                                warn!(assignment_id = %update.id, error = %e, "Failed to download worker-oriented assignment");
+                            }
+                        }
+                        continue;
+                    }
+
                     tracing::debug!("Downloading assignment \"{}\"", update.id);
                     let assignment = match super::assignments::fetch_assignment(
                         &update.fb_url_v1,


### PR DESCRIPTION
## Summary

Adds discovery and decoding support for the new `WorkerAssignment` type (from NET-1180), without touching real chunk-serving. Scope is deliberately narrow — infra only, not a switch-over.

- `visible_assignment()` now prefers `NetworkState.worker_assignment`, falling back to the legacy `assignment` pointer — mirrors the pattern already used in sqd-portal (PR #125), gated behind `mvcc-chunks`.
- `fetch_worker_assignment()` decodes `sqd_assignments::WorkerAssignment` alongside the untouched legacy `fetch_assignment()`; shared gzip-download logic factored out into `download_gzipped()`.
- In `p2p.rs`: when an update is sourced from `worker_assignment`, it's decoded and logged only — never fed to the legacy parser. `DatasetsIndex` and actual chunk-serving stay on the legacy path entirely.

## Notes

- **Out of scope**: switching real chunk-serving over to the new format. `WorkerAssignmentChunk` has no `files`/`base_url` — deriving them from `schema_id`/`tables_present` needs the schema delivery mechanism, which is separate, not-yet-scoped work (tracked against NET-1180's design doc, not this ticket).
- Temporarily pins `sqd-assignments` to NET-1180's branch commit (`1e334ec`) in both `[dependencies]` and `[dev-dependencies]`, since the new types aren't on sqd-network's master yet. Marked `# TEMPORARY` — needs re-pinning to master once [sqd-network#214](https://github.com/subsquid/sqd-network/pull/214) merges.

## Test plan

- [x] `cargo check` / `test` / `clippy -D warnings` / `fmt --check` clean, both with and without `mvcc-chunks`
- [x] Full suite (lib + `e2e` + `query_concurrency` + `query_surface`), 97 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)